### PR TITLE
API 관련 세팅 #6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@tanstack/react-query-devtools": "^4.33.0",
         "@types/lodash": "^4.14.197",
         "axios": "^1.5.0",
+        "dotenv": "^16.3.1",
         "framer-motion": "^10.16.3",
         "lodash": "^4.17.21",
         "react": "^18.2.0",
@@ -3372,6 +3373,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/eastasianwidth": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@tanstack/react-query-devtools": "^4.33.0",
     "@types/lodash": "^4.14.197",
     "axios": "^1.5.0",
+    "dotenv": "^16.3.1",
     "framer-motion": "^10.16.3",
     "lodash": "^4.17.21",
     "react": "^18.2.0",

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -9,7 +9,7 @@ export const formDataInstance = axios.create({ baseURL });
 authInstance.interceptors.request.use(
   (config) => {
     // TODO: 임시 코드입니다. 이후에 로그인 토큰 저장 관련 로직 작성시 수정해야 합니다.
-    const token = localStorage.getItem('token');
+    const token = sessionStorage.getItem('token');
 
     if (token) {
       config.headers['Authorization'] = `Bearer ${token}`;
@@ -25,7 +25,7 @@ authInstance.interceptors.request.use(
 formDataInstance.interceptors.request.use(
   (config) => {
     // TODO: 임시 코드입니다. 이후에 로그인 토큰 저장 관련 로직 작성시 수정해야 합니다.
-    const token = localStorage.getItem('token');
+    const token = sessionStorage.getItem('token');
 
     if (token) {
       config.headers['Authorization'] = `Bearer ${token}`;

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -1,0 +1,40 @@
+import axios from 'axios';
+
+const baseURL = import.meta.env.VITE_API_ENDPOINT;
+
+export const baseInstance = axios.create({ baseURL });
+export const authInstance = axios.create({ baseURL });
+export const formDataInstance = axios.create({ baseURL });
+
+authInstance.interceptors.request.use(
+  (config) => {
+    // TODO: 임시 코드입니다. 이후에 로그인 토큰 저장 관련 로직 작성시 수정해야 합니다.
+    const token = localStorage.getItem('token');
+
+    if (token) {
+      config.headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+formDataInstance.interceptors.request.use(
+  (config) => {
+    // TODO: 임시 코드입니다. 이후에 로그인 토큰 저장 관련 로직 작성시 수정해야 합니다.
+    const token = localStorage.getItem('token');
+
+    if (token) {
+      config.headers['Authorization'] = `Bearer ${token}`;
+    }
+    config.headers['Content-Type'] = 'multipart/form-data';
+
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);

--- a/src/apis/mutations/useLoginMutation.ts
+++ b/src/apis/mutations/useLoginMutation.ts
@@ -1,0 +1,28 @@
+import { AxiosError } from 'axios';
+import { useMutation } from '@tanstack/react-query';
+import { baseInstance } from '@/apis/instance';
+
+interface RequestParams {
+  email: string;
+  password: string;
+}
+
+interface ResponseData {
+  user: unknown; // TODO: 임시로 unknown으로 설정했습니다.
+  token: string;
+}
+
+const useLoginMutation = () => {
+  return useMutation<ResponseData, AxiosError, RequestParams>({
+    mutationFn: async (params: RequestParams) => {
+      const { data } = await baseInstance.post('/login', params);
+      return data;
+    },
+    onSuccess: (data) => {
+      // TODO: 임시 코드입니다. 이후에 로그인 토큰 저장 관련 로직 작성시 수정해야 합니다.
+      localStorage.setItem('token', data.token);
+    }
+  });
+};
+
+export default useLoginMutation;

--- a/src/apis/mutations/useLoginMutation.ts
+++ b/src/apis/mutations/useLoginMutation.ts
@@ -1,8 +1,8 @@
-import { AxiosError } from 'axios';
 import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 import { baseInstance } from '@/apis/instance';
 
-interface RequestParams {
+interface RequestData {
   email: string;
   password: string;
 }
@@ -12,15 +12,17 @@ interface ResponseData {
   token: string;
 }
 
+const postLogin = async (params: RequestData) => {
+  const { data } = await baseInstance.post('/login', params);
+  return data;
+};
+
 const useLoginMutation = () => {
-  return useMutation<ResponseData, AxiosError, RequestParams>({
-    mutationFn: async (params: RequestParams) => {
-      const { data } = await baseInstance.post('/login', params);
-      return data;
-    },
+  return useMutation<ResponseData, AxiosError, RequestData>({
+    mutationFn: postLogin,
     onSuccess: (data) => {
       // TODO: 임시 코드입니다. 이후에 로그인 토큰 저장 관련 로직 작성시 수정해야 합니다.
-      localStorage.setItem('token', data.token);
+      sessionStorage.setItem('token', data.token);
     }
   });
 };

--- a/src/apis/queries/useAuthCheckQuery.ts
+++ b/src/apis/queries/useAuthCheckQuery.ts
@@ -1,15 +1,21 @@
 import { useQuery } from '@tanstack/react-query';
 import { authInstance } from '@/apis/instance';
 import queryKey from '@/apis/queryKeys';
+import type { QueryOptions } from '@/apis/types';
 
-const useAuthCheckQuery = () => {
-  return useQuery({
+// TODO: 응답 데이터를 임시로 비워뒀습니다. 원래의 데이터는 User 모델과 동일합니다.
+interface ResponseData {}
+
+export const getAuthUser = async () => {
+  const { data } = await authInstance.get<ResponseData>('/auth-user');
+  return data;
+};
+
+const useAuthCheckQuery = (options?: QueryOptions<ResponseData>) => {
+  return useQuery<ResponseData>({
     queryKey: queryKey.auth,
-    queryFn: async () => {
-      // TODO: 응답 데이터를 임시로 unknown으로 설정했습니다.
-      const { data } = await authInstance.get<unknown>('/auth-user');
-      return data;
-    }
+    queryFn: getAuthUser,
+    ...options
   });
 };
 

--- a/src/apis/queries/useAuthCheckQuery.ts
+++ b/src/apis/queries/useAuthCheckQuery.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import { authInstance } from '@/apis/instance';
+import queryKey from '@/apis/queryKeys';
+
+const useAuthCheckQuery = () => {
+  return useQuery({
+    queryKey: queryKey.auth,
+    queryFn: async () => {
+      // TODO: 응답 데이터를 임시로 unknown으로 설정했습니다.
+      const { data } = await authInstance.get<unknown>('/auth-user');
+      return data;
+    }
+  });
+};
+
+export default useAuthCheckQuery;

--- a/src/apis/queryKeys.ts
+++ b/src/apis/queryKeys.ts
@@ -1,0 +1,9 @@
+const queryKey = {
+  auth: ['auth'] as const,
+  users: {
+    all: ['users'] as const,
+    detail: (id: number) => ['users', id] as const
+  }
+};
+
+export default queryKey;

--- a/src/apis/types.ts
+++ b/src/apis/types.ts
@@ -1,0 +1,4 @@
+import type { UseQueryOptions, UseMutationOptions } from '@tanstack/react-query';
+
+export type QueryOptions<T> = Omit<UseQueryOptions<T>, 'queryKey' | 'queryFn'>;
+export type MutationOptions<T> = Omit<UseMutationOptions<T>, 'mutationKey' | 'mutationFn'>;

--- a/src/apis/types.ts
+++ b/src/apis/types.ts
@@ -1,4 +1,3 @@
-import type { UseQueryOptions, UseMutationOptions } from '@tanstack/react-query';
+import type { UseQueryOptions } from '@tanstack/react-query';
 
 export type QueryOptions<T> = Omit<UseQueryOptions<T>, 'queryKey' | 'queryFn'>;
-export type MutationOptions<T> = Omit<UseMutationOptions<T>, 'mutationKey' | 'mutationFn'>;


### PR DESCRIPTION
## 👩‍💻 요구 사항과 구현 내용
- 공통적으로 사용할 수 있는 axios 인스턴스를 만들었습니다.
  - baseInstance 기본 인스턴스로, baseURL 정보만 들어있는 인스턴스입니다.
  - authInstance: 로그인 토큰이 헤더에 들어가는 인스턴스입니다.
  - formDataInstance: 로그인 토큰과 content-type에 대한 정보가 헤더에 들어가는 인스턴스입니다.
- 쿼리 키를 상수로 정의해놓는 기본 틀을 작성했습니다. (queryKey.ts)
- 로그인에 대한 POST 요청을 처리하는 useLoginMutation 훅을 만들었습니다.
- 로그인 확인에 대한 GET 요청을 처리하는 useAuthCheckQuery 훅을 만들었습니다.
- API 엔드포인트를 숨기기 위하여 dotenv 패키지를 설치했습니다.

## ✅ 포인트
- 우선은 세션스토리지에 로그인 토큰을 관리하는 부분을 임시로 하드코딩해서 작성된 느낌이라, 추후에 회원가입/로그인 기능을 작성하면서 수정이 필요해보입니다.
- API 요청의 응답 데이터가 User 모델인데, 우선 타입 정의에 대한 부분을 어떻게 할지 논의가 필요할 듯 하여서 우선 unknown 타입을 부여하였습니다.
- env 파일의 공유에 대한 부분의 논의가 필요해보입니다.