### PR TITLE
feat: 로그인 페이지 구현

### DIFF
--- a/src/apis/mutations/useSigninMutation.ts
+++ b/src/apis/mutations/useSigninMutation.ts
@@ -17,7 +17,7 @@ const postLogin = async (params: RequestData) => {
   return data;
 };
 
-const useLoginMutation = () => {
+const useSigninMutation = () => {
   return useMutation<ResponseData, AxiosError, RequestData>({
     mutationFn: postLogin,
     onSuccess: (data) => {
@@ -27,4 +27,4 @@ const useLoginMutation = () => {
   });
 };
 
-export default useLoginMutation;
+export default useSigninMutation;

--- a/src/pages/Signin/index.tsx
+++ b/src/pages/Signin/index.tsx
@@ -81,14 +81,7 @@ const SignIn = () => {
         }}
         registerProps={register('password')}
       />
-      <Button
-        type="submit"
-        mt="6"
-        w="100%"
-        color="white"
-        backgroundColor="green01"
-        _hover={{ backgroundColor: 'green03' }}
-        _active={{ backgroundColor: 'green.500' }}>
+      <Button type="submit" mt="6" w="100%" colorScheme="primary">
         Sign in
       </Button>
       <LinkTemplate>

--- a/src/pages/Signin/index.tsx
+++ b/src/pages/Signin/index.tsx
@@ -1,8 +1,76 @@
+import { Link } from 'react-router-dom';
+import { Image, Heading, Button, Text, Flex } from '@chakra-ui/react';
+import { EmailIcon } from '@chakra-ui/icons';
+import musseuk from '@/assets/images/musseuk_hood.png';
+import InputField from '@/pages/Signup/components/InputField';
+import { PageTemplate, LinkTemplate } from '@/pages/Signup/templates';
+
+const links = {
+  signup: '/signup'
+};
+
 const SignIn = () => {
   return (
-    <>
-      <h1>Signin page</h1>
-    </>
+    <PageTemplate>
+      <Image maxW="32" src={musseuk} alt="머쓱이" />
+      <Heading textAlign="center">Sign in</Heading>
+      <Flex
+        color="gray.500"
+        justifyContent="center"
+        alignItems="center"
+        flexWrap="wrap"
+        gap="2"
+        fontSize="lg"
+        textAlign="center"
+        fontWeight="light">
+        Welcome to 머쓱레터 <EmailIcon />
+      </Flex>
+      <InputField
+        label="Email"
+        inputProps={{
+          id: 'email',
+          type: 'email',
+          placeholder: '이메일을 입력해주세요'
+        }}
+      />
+      <InputField
+        label="Password"
+        inputProps={{
+          id: 'password',
+          type: 'password',
+          placeholder: '비밀번호를 입력해주세요',
+          maxLength: 30
+        }}
+      />
+      <Button
+        type="submit"
+        mt="6"
+        w="100%"
+        color="white"
+        backgroundColor="green01"
+        _hover={{ backgroundColor: 'green03' }}
+        _active={{ backgroundColor: 'green.500' }}>
+        Sign in
+      </Button>
+      <LinkTemplate>
+        <Text color="gray.400">No account yet?</Text>
+        <Link to={links.signup}>
+          <Text
+            color="green.500"
+            _hover={{
+              color: 'green.600'
+            }}
+            _active={{
+              color: 'green.700'
+            }}
+            fontWeight="semibold"
+            cursor="pointer"
+            userSelect="none">
+            Create an account
+          </Text>
+        </Link>
+      </LinkTemplate>
+    </PageTemplate>
   );
 };
 

--- a/src/pages/Signup/components/InputField.tsx
+++ b/src/pages/Signup/components/InputField.tsx
@@ -21,7 +21,7 @@ const InputField = ({
         {label}
       </FormLabel>
       <InputGroup>
-        <Input w="100%" borderColor="blue01" {...inputProps} {...registerProps} />
+        <Input w="100%" borderColor="blue01" fontWeight="light" {...inputProps} {...registerProps} />
         {icon && <InputRightElement cursor="pointer">{icon}</InputRightElement>}
       </InputGroup>
       <FormErrorMessage fontSize="sm" color="red01">

--- a/src/pages/Signup/index.tsx
+++ b/src/pages/Signup/index.tsx
@@ -7,11 +7,7 @@ import { ViewIcon, ViewOffIcon } from '@chakra-ui/icons';
 import useSignupMutation from '@/apis/mutations/useSignupMutation';
 import musseuk from '@/assets/images/musseuk_hood.png';
 import InputField from './components/InputField';
-
-const colors = {
-  background: '#F2F8EB',
-  submit: '#8CD790'
-};
+import PageTemplate from './templates/PageTemplate';
 
 const links = {
   main: '/',
@@ -74,112 +70,95 @@ const SignUp = () => {
   const onError: SubmitErrorHandler<Inputs> = (errors) => console.error(errors);
 
   return (
-    <Flex w="100%" px="4" py="8" minH="100vh" bg={colors.background} justifyContent="center" alignItems="center">
-      <Flex
-        as="form"
-        onSubmit={handleSubmit(onSubmit, onError)}
-        px={['8', '16', '24']}
-        py={['6', '8', '12']}
+    <PageTemplate onSubmit={handleSubmit(onSubmit, onError)}>
+      <Image maxW="32" src={musseuk} alt="머쓱이" />
+      <Heading textAlign="center">Sign up</Heading>
+      <InputField
+        label="Email"
+        error={errors.email}
+        inputProps={{
+          id: 'email',
+          type: 'email',
+          placeholder: '이메일을 입력해주세요'
+        }}
+        registerProps={register('email')}
+      />
+      <InputField
+        label="Username"
+        error={errors.username}
+        inputProps={{
+          id: 'username',
+          type: 'text',
+          placeholder: '실명을 입력해주세요',
+          maxLength: 4
+        }}
+        registerProps={register('username')}
+      />
+      <InputField
+        label="Password"
+        inputProps={{
+          id: 'password',
+          type: showPassword ? 'text' : 'password',
+          placeholder: '비밀번호를 입력해주세요',
+          maxLength: 30
+        }}
+        registerProps={register('password')}
+        icon={<Icon as={showPassword ? ViewOffIcon : ViewIcon} onClick={setShowPassword.toggle} />}
+      />
+      <Box w="100%" fontSize="sm">
+        {isPasswordShort && <Text>· Length must be greater than 8 characters</Text>}
+        {!isPasswordContainNumber && <Text color="green03">· Password must contain numbers</Text>}
+      </Box>
+      <InputField
+        label="Confirm Password"
+        error={errors.confirmPassword}
+        inputProps={{
+          id: 'confirm-password',
+          type: showConfirmPassword ? 'text' : 'password',
+          placeholder: '비밀번호를 재확인해주세요',
+          maxLength: 30
+        }}
+        registerProps={register('confirmPassword')}
+        icon={<Icon as={showConfirmPassword ? ViewOffIcon : ViewIcon} onClick={setShowConfirmPassword.toggle} />}
+      />
+      <Button
+        type="submit"
+        mt="6"
         w="100%"
-        maxW="xl"
-        bg="white"
-        boxSizing="border-box"
-        boxShadow="lg"
-        borderRadius="20px"
-        flexDir="column"
-        gap="2"
-        justifyContent="center"
+        color="white"
+        backgroundColor="green01"
+        _hover={{ backgroundColor: 'green03' }}
+        _active={{ backgroundColor: 'green.500' }}>
+        Create account
+      </Button>
+      <Flex
+        mt="3"
+        w="100%"
+        direction={['column', 'row']}
+        justifyContent="space-around"
         alignItems="center"
-        transition="padding 0.25s ease-in-out">
-        <Image maxW="32" src={musseuk} alt="머쓱이" />
-        <Heading textAlign="center">Sign up</Heading>
-        <InputField
-          label="Email"
-          error={errors.email}
-          inputProps={{
-            id: 'email',
-            type: 'email',
-            placeholder: '이메일을 입력해주세요'
-          }}
-          registerProps={register('email')}
-        />
-        <InputField
-          label="Username"
-          error={errors.username}
-          inputProps={{
-            id: 'username',
-            type: 'text',
-            placeholder: '실명을 입력해주세요',
-            maxLength: 4
-          }}
-          registerProps={register('username')}
-        />
-        <InputField
-          label="Password"
-          inputProps={{
-            id: 'password',
-            type: showPassword ? 'text' : 'password',
-            placeholder: '비밀번호를 입력해주세요',
-            maxLength: 30
-          }}
-          registerProps={register('password')}
-          icon={<Icon as={showPassword ? ViewOffIcon : ViewIcon} onClick={setShowPassword.toggle} />}
-        />
-        <Box w="100%" fontSize="sm">
-          {isPasswordShort && <Text>· Length must be greater than 8 characters</Text>}
-          {!isPasswordContainNumber && <Text color="green03">· Password must contain numbers</Text>}
-        </Box>
-        <InputField
-          label="Confirm Password"
-          error={errors.confirmPassword}
-          inputProps={{
-            id: 'confirm-password',
-            type: showConfirmPassword ? 'text' : 'password',
-            placeholder: '비밀번호를 재확인해주세요',
-            maxLength: 30
-          }}
-          registerProps={register('confirmPassword')}
-          icon={<Icon as={showConfirmPassword ? ViewOffIcon : ViewIcon} onClick={setShowConfirmPassword.toggle} />}
-        />
-        <Button
-          type="submit"
-          mt="6"
-          w="100%"
-          color="white"
-          backgroundColor="green01"
-          _hover={{ backgroundColor: 'green03' }}
-          _active={{ backgroundColor: 'green.500' }}>
-          Create account
-        </Button>
-        <Flex
-          mt="3"
-          w="100%"
-          direction={['column', 'row']}
-          justifyContent="space-around"
-          alignItems="center"
-          transition="color 0.2s"
-          gap="1"
-          fontSize="sm"
-          textAlign="center">
-          <Text color="gray.400">Already have an account?</Text>
-          <Link to={links.signin}>
-            <Text
-              color="green.500"
-              _hover={{
-                color: 'green.600'
-              }}
-              _active={{
-                color: 'green.700'
-              }}
-              fontWeight="semibold"
-              cursor="pointer"
-              userSelect="none">
-              Sign in
-            </Text>
-          </Link>
-        </Flex>
+        transition="color 0.2s"
+        gap="1"
+        fontSize="sm"
+        textAlign="center">
+        <Text color="gray.400">Already have an account?</Text>
+        <Link to={links.signin}>
+          <Text
+            color="green.500"
+            _hover={{
+              color: 'green.600'
+            }}
+            _active={{
+              color: 'green.700'
+            }}
+            fontWeight="semibold"
+            cursor="pointer"
+            userSelect="none">
+            Sign in
+          </Text>
+        </Link>
       </Flex>
-    </Flex>
+    </PageTemplate>
   );
 };
 

--- a/src/pages/Signup/index.tsx
+++ b/src/pages/Signup/index.tsx
@@ -7,7 +7,7 @@ import { ViewIcon, ViewOffIcon } from '@chakra-ui/icons';
 import useSignupMutation from '@/apis/mutations/useSignupMutation';
 import musseuk from '@/assets/images/musseuk_hood.png';
 import InputField from './components/InputField';
-import PageTemplate from './templates/PageTemplate';
+import { PageTemplate, LinkTemplate } from './templates';
 
 const links = {
   main: '/',
@@ -131,16 +131,7 @@ const SignUp = () => {
         _active={{ backgroundColor: 'green.500' }}>
         Create account
       </Button>
-      <Flex
-        mt="3"
-        w="100%"
-        direction={['column', 'row']}
-        justifyContent="space-around"
-        alignItems="center"
-        transition="color 0.2s"
-        gap="1"
-        fontSize="sm"
-        textAlign="center">
+      <LinkTemplate>
         <Text color="gray.400">Already have an account?</Text>
         <Link to={links.signin}>
           <Text
@@ -157,7 +148,7 @@ const SignUp = () => {
             Sign in
           </Text>
         </Link>
-      </Flex>
+      </LinkTemplate>
     </PageTemplate>
   );
 };

--- a/src/pages/Signup/index.tsx
+++ b/src/pages/Signup/index.tsx
@@ -106,8 +106,8 @@ const SignUp = () => {
         icon={<Icon as={showPassword ? ViewOffIcon : ViewIcon} onClick={setShowPassword.toggle} />}
       />
       <Box w="100%" fontSize="sm">
-        {isPasswordShort && <Text>· Length must be greater than 8 characters</Text>}
-        {!isPasswordContainNumber && <Text color="green03">· Password must contain numbers</Text>}
+        {isPasswordShort && <Text fontWeight="light">· Length must be greater than 8 characters</Text>}
+        {!isPasswordContainNumber && <Text fontWeight="light">· Password must contain numbers</Text>}
       </Box>
       <InputField
         label="Confirm Password"

--- a/src/pages/Signup/index.tsx
+++ b/src/pages/Signup/index.tsx
@@ -2,7 +2,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useForm, SubmitHandler, SubmitErrorHandler } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Box, Button, Icon, Flex, Heading, Text, Image, useBoolean } from '@chakra-ui/react';
+import { Box, Button, Icon, Heading, Text, Image, useBoolean } from '@chakra-ui/react';
 import { ViewIcon, ViewOffIcon } from '@chakra-ui/icons';
 import useSignupMutation from '@/apis/mutations/useSignupMutation';
 import musseuk from '@/assets/images/musseuk_hood.png';

--- a/src/pages/Signup/index.tsx
+++ b/src/pages/Signup/index.tsx
@@ -1,7 +1,7 @@
 import { Link, useNavigate } from 'react-router-dom';
 import { useForm, SubmitHandler, SubmitErrorHandler } from 'react-hook-form';
-import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
 import { Box, Button, Icon, Heading, Text, Image, useBoolean } from '@chakra-ui/react';
 import { ViewIcon, ViewOffIcon } from '@chakra-ui/icons';
 import useSignupMutation from '@/apis/mutations/useSignupMutation';

--- a/src/pages/Signup/templates/LinkTemplate.tsx
+++ b/src/pages/Signup/templates/LinkTemplate.tsx
@@ -1,0 +1,20 @@
+import { Flex } from '@chakra-ui/react';
+
+const LinkTemplate = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <Flex
+      mt="3"
+      w="100%"
+      direction={['column', 'row']}
+      justifyContent="space-around"
+      alignItems="center"
+      transition="color 0.2s"
+      gap="1"
+      fontSize="sm"
+      textAlign="center">
+      {children}
+    </Flex>
+  );
+};
+
+export default LinkTemplate;

--- a/src/pages/Signup/templates/PageTemplate.tsx
+++ b/src/pages/Signup/templates/PageTemplate.tsx
@@ -15,6 +15,7 @@ const PageTemplate = ({ children, ...props }: FlexProps & React.FormHTMLAttribut
         py={['6', '8', '12']}
         w="100%"
         maxW="xl"
+        minH="3xl"
         bg="white"
         boxSizing="border-box"
         boxShadow="lg"

--- a/src/pages/Signup/templates/PageTemplate.tsx
+++ b/src/pages/Signup/templates/PageTemplate.tsx
@@ -1,0 +1,33 @@
+import { Flex } from '@chakra-ui/react';
+import type { FlexProps } from '@chakra-ui/react';
+
+const colors = {
+  background: '#F2F8EB'
+};
+
+const PageTemplate = ({ children, ...props }: FlexProps & React.FormHTMLAttributes<HTMLFormElement>) => {
+  return (
+    <Flex w="100%" px="4" py="8" minH="100vh" bg={colors.background} justifyContent="center" alignItems="center">
+      <Flex
+        {...props}
+        as="form"
+        px={['8', '16', '24']}
+        py={['6', '8', '12']}
+        w="100%"
+        maxW="xl"
+        bg="white"
+        boxSizing="border-box"
+        boxShadow="lg"
+        borderRadius="20px"
+        flexDir="column"
+        gap="2"
+        justifyContent="center"
+        alignItems="center"
+        transition="padding 0.25s ease-in-out">
+        {children}
+      </Flex>
+    </Flex>
+  );
+};
+
+export default PageTemplate;

--- a/src/pages/Signup/templates/index.ts
+++ b/src/pages/Signup/templates/index.ts
@@ -1,0 +1,2 @@
+export { default as LinkTemplate } from './LinkTemplate';
+export { default as PageTemplate } from './PageTemplate';


### PR DESCRIPTION
## 🧩 이슈 번호 <!-- 이슈번호를 작성해주세요 ex) #11 -->
- close #34 

## ✅ 작업 사항 <!-- 가능한 구체적으로 작성해주세요 -->
- 로그인 페이지 UI 구성
- 로그인 페이지 로직 작성
- 회원가입 페이지, 로그인 페이지에서 사용되는 공통 템플릿 컴포넌트 추상화

## 👩‍💻 공유 포인트 및 논의 사항 
- 로그인 된 상태에 signup, signin 페이지에 접근하는 것을 막는 동작은 아직 작성하지 않았어요. 추가적인 작업이 필요해요.
- 우선은 임시로 로그인 토큰을 세션 스토리지에 하드코딩해서 넣는 동작을 넣어놨는데, 로그인한 사용자의 정보를 비롯한 토큰 정보를 관리하는 로직에 대한 수정이 필요해요.