### PR TITLE
feat: 포스트 페이지 API 연결

### DIFF
--- a/src/apis/queries/usePostDetailQuery.ts
+++ b/src/apis/queries/usePostDetailQuery.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+import { baseInstance } from '@/apis/instance';
+import { PostResponse } from '@/apis/types';
+import queryKey from '@/apis/queryKeys';
+
+export const getPostDetail = async (id: number) => {
+  const { data } = await baseInstance.get<PostResponse>(`/posts/${id}`);
+
+  return data;
+};
+
+const usePostDetailQuery = (id: number) => {
+  return useQuery<PostResponse>({
+    queryKey: queryKey.posts.detail(id),
+    queryFn: () => getPostDetail(id)
+  });
+};
+
+export default usePostDetailQuery;

--- a/src/apis/queries/usePostDetailQuery.ts
+++ b/src/apis/queries/usePostDetailQuery.ts
@@ -2,15 +2,17 @@ import { useQuery } from '@tanstack/react-query';
 import { baseInstance } from '@/apis/instance';
 import { PostResponse } from '@/apis/types';
 import queryKey from '@/apis/queryKeys';
+import parsePost from '../utils/parsePost';
+import { Post } from '@/types';
 
 export const getPostDetail = async (id: number) => {
   const { data } = await baseInstance.get<PostResponse>(`/posts/${id}`);
 
-  return data;
+  return parsePost(data);
 };
 
 const usePostDetailQuery = (id: number) => {
-  return useQuery<PostResponse>({
+  return useQuery<Post>({
     queryKey: queryKey.posts.detail(id),
     queryFn: () => getPostDetail(id)
   });

--- a/src/apis/queries/usePostDetailQuery.ts
+++ b/src/apis/queries/usePostDetailQuery.ts
@@ -5,13 +5,13 @@ import queryKey from '@/apis/queryKeys';
 import parsePost from '../utils/parsePost';
 import { Post } from '@/types';
 
-export const getPostDetail = async (id: number) => {
+export const getPostDetail = async (id: string) => {
   const { data } = await baseInstance.get<PostResponse>(`/posts/${id}`);
 
   return parsePost(data);
 };
 
-const usePostDetailQuery = (id: number) => {
+const usePostDetailQuery = (id: string) => {
   return useQuery<Post>({
     queryKey: queryKey.posts.detail(id),
     queryFn: () => getPostDetail(id)

--- a/src/apis/queryKeys.ts
+++ b/src/apis/queryKeys.ts
@@ -7,8 +7,8 @@ const queryKey = {
   },
   posts: {
     all: ['posts'] as const,
-    detail: (id: number) => ['posts', id] as const,
-    search: (userId: number) => ['posts', 'search', userId] as const
+    detail: (id: string) => ['posts', id] as const,
+    search: (userId: string) => ['posts', 'search', userId] as const
   }
 };
 

--- a/src/apis/queryKeys.ts
+++ b/src/apis/queryKeys.ts
@@ -4,6 +4,11 @@ const queryKey = {
     all: ['users'] as const,
     detail: (id: number) => ['users', id] as const,
     search: (keyword: string) => ['users', 'search', keyword] as const
+  },
+  posts: {
+    all: ['posts'] as const,
+    detail: (id: number) => ['posts', id] as const,
+    search: (userId: number) => ['posts', 'search', userId] as const
   }
 };
 

--- a/src/apis/types.ts
+++ b/src/apis/types.ts
@@ -9,7 +9,7 @@ export interface UserResponse {
   emailVerified: boolean; // 사용되지 않음
   banned: boolean; // 사용되지 않음
   isOnline: boolean;
-  posts: PostResponse[];
+  posts: PostResponse[] | string[];
   likes: LikeResponse[];
   comments: string[];
   followers: [];

--- a/src/apis/types.ts
+++ b/src/apis/types.ts
@@ -44,7 +44,7 @@ export interface ChannelResponse {
 
 export interface PostResponse {
   likes: LikeResponse[];
-  comments: Comment[];
+  comments: CommentResponse[];
   _id: string;
   image?: string;
   imagePublicId?: string;

--- a/src/apis/utils/parseComment.ts
+++ b/src/apis/utils/parseComment.ts
@@ -4,7 +4,28 @@ import { CommentResponse } from '../types';
 const parseComment = (rawComment: CommentResponse) => {
   const { _id, comment: commentJSON } = rawComment;
 
-  const { content, pos, nickname, decorationImageName } = JSON.parse(commentJSON) as CommentField;
+  let commentData: CommentField;
+  try {
+    commentData = JSON.parse(commentJSON) as CommentField;
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      commentData = {
+        content: '',
+        pos: [0, 0],
+        nickname: '익명의 머쓱이',
+        decorationImageName: 'decoration_soju1'
+      };
+    } else {
+      throw err;
+    }
+  }
+
+  const {
+    content = '',
+    pos = [0, 0],
+    nickname = '익명의 머쓱이',
+    decorationImageName = 'decoration_soju1'
+  } = commentData;
 
   const comment: Comment = {
     _id,

--- a/src/apis/utils/parseComment.ts
+++ b/src/apis/utils/parseComment.ts
@@ -1,19 +1,20 @@
-import { Comment, customCommentComment } from '@/types';
+import { Comment, CommentField } from '@/types';
 import { CommentResponse } from '../types';
 
 const parseComment = (rawComment: CommentResponse) => {
   const { _id, comment: commentJSON } = rawComment;
 
-  const { content, pos, nickname } = JSON.parse(commentJSON) as customCommentComment;
+  const { content, pos, nickname, decorationImageName } = JSON.parse(commentJSON) as CommentField;
 
-  const customComment: Comment = {
+  const comment: Comment = {
     _id,
     content,
     pos,
-    nickname
+    nickname,
+    decorationImageName
   };
 
-  return customComment;
+  return comment;
 };
 
 export default parseComment;

--- a/src/apis/utils/parseComment.ts
+++ b/src/apis/utils/parseComment.ts
@@ -1,0 +1,19 @@
+import { Comment, customCommentComment } from '@/types';
+import { CommentResponse } from '../types';
+
+const parseComment = (rawComment: CommentResponse) => {
+  const { _id, comment: commentJSON } = rawComment;
+
+  const { content, pos, nickname } = JSON.parse(commentJSON) as customCommentComment;
+
+  const customComment: Comment = {
+    _id,
+    content,
+    pos,
+    nickname
+  };
+
+  return customComment;
+};
+
+export default parseComment;

--- a/src/apis/utils/parsePost.ts
+++ b/src/apis/utils/parsePost.ts
@@ -1,0 +1,25 @@
+import { Post, customPostTitle } from '@/types';
+import { PostResponse } from '../types';
+import parseComment from './parseComment';
+import parseUser from './parseUser';
+
+const parsePost = (rawPost: PostResponse) => {
+  const { _id, title: titleJSON, comments: rawComments, author: rawAuthor } = rawPost;
+
+  const { title, content, musseukId } = JSON.parse(titleJSON) as customPostTitle;
+  const comments = rawComments.map((comment) => parseComment(comment));
+  const author = parseUser(rawAuthor);
+
+  const customPost: Post = {
+    _id,
+    title,
+    content,
+    musseukId,
+    comments,
+    author
+  };
+
+  return customPost;
+};
+
+export default parsePost;

--- a/src/apis/utils/parsePost.ts
+++ b/src/apis/utils/parsePost.ts
@@ -6,9 +6,25 @@ import parseUser from './parseUser';
 const parsePost = (rawPost: PostResponse) => {
   const { _id, title: titleJSON, comments: rawComments, author: rawAuthor } = rawPost;
 
-  const { title, content, musseukImageName } = JSON.parse(titleJSON) as PostTitle;
   const comments = rawComments.map((comment) => parseComment(comment));
   const author = parseUser(rawAuthor);
+
+  let titleData: PostTitle;
+  try {
+    titleData = JSON.parse(titleJSON) as PostTitle;
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      titleData = {
+        title: '머쓱이',
+        content: '',
+        musseukImageName: 'musseuk_default'
+      };
+    } else {
+      throw err;
+    }
+  }
+
+  const { title = '머쓱이', content = '', musseukImageName = 'musseuk_default' } = titleData;
 
   const post: Post = {
     _id,

--- a/src/apis/utils/parsePost.ts
+++ b/src/apis/utils/parsePost.ts
@@ -1,4 +1,4 @@
-import { Post, customPostTitle } from '@/types';
+import { Post, PostTitle } from '@/types';
 import { PostResponse } from '../types';
 import parseComment from './parseComment';
 import parseUser from './parseUser';
@@ -6,20 +6,20 @@ import parseUser from './parseUser';
 const parsePost = (rawPost: PostResponse) => {
   const { _id, title: titleJSON, comments: rawComments, author: rawAuthor } = rawPost;
 
-  const { title, content, musseukId } = JSON.parse(titleJSON) as customPostTitle;
+  const { title, content, musseukImageName } = JSON.parse(titleJSON) as PostTitle;
   const comments = rawComments.map((comment) => parseComment(comment));
   const author = parseUser(rawAuthor);
 
-  const customPost: Post = {
+  const post: Post = {
     _id,
     title,
     content,
-    musseukId,
+    musseukImageName,
     comments,
     author
   };
 
-  return customPost;
+  return post;
 };
 
 export default parsePost;

--- a/src/apis/utils/parseUser.ts
+++ b/src/apis/utils/parseUser.ts
@@ -4,13 +4,30 @@ import { UserResponse } from '../types';
 const parseUser = (rawUser: UserResponse) => {
   const { _id, email, fullName: fullNameJSON, image, posts, comments } = rawUser;
 
-  const { username, introduce } = JSON.parse(fullNameJSON) as UserFullName;
+  let fullNameData: UserFullName;
+  try {
+    fullNameData = JSON.parse(fullNameJSON) as UserFullName;
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      fullNameData = {
+        username: '머쓱이',
+        introduce: '안녕하세요 머쓱이입니다'
+      };
+    } else {
+      throw err;
+    }
+  }
+
+  const { username, introduce = `안녕하세요 ${username}입니다`, slackId, slackWorkspace } = fullNameData;
 
   const user: User = {
     _id,
     email,
     username,
     introduce,
+    slackId,
+    slackWorkspace,
+    // TODO: default image를 binary 데이터로 설정해주기?
     image,
     postCount: posts.length,
     commentCount: comments.length

--- a/src/apis/utils/parseUser.ts
+++ b/src/apis/utils/parseUser.ts
@@ -1,21 +1,22 @@
-import { User, customUserFullName } from '@/types';
+import { User, UserFullName } from '@/types';
 import { UserResponse } from '../types';
 
 const parseUser = (rawUser: UserResponse) => {
-  const { _id, email, fullName: fullNameJSON, image } = rawUser;
+  const { _id, email, fullName: fullNameJSON, image, posts, comments } = rawUser;
 
-  const { username, nickname, introduce } = JSON.parse(fullNameJSON) as customUserFullName;
+  const { username, introduce } = JSON.parse(fullNameJSON) as UserFullName;
 
-  const customUser: User = {
+  const user: User = {
     _id,
     email,
     username,
-    nickname,
     introduce,
-    image
+    image,
+    postCount: posts.length,
+    commentCount: comments.length
   };
 
-  return customUser;
+  return user;
 };
 
 export default parseUser;

--- a/src/apis/utils/parseUser.ts
+++ b/src/apis/utils/parseUser.ts
@@ -1,0 +1,21 @@
+import { User, customUserFullName } from '@/types';
+import { UserResponse } from '../types';
+
+const parseUser = (rawUser: UserResponse) => {
+  const { _id, email, fullName: fullNameJSON, image } = rawUser;
+
+  const { username, nickname, introduce } = JSON.parse(fullNameJSON) as customUserFullName;
+
+  const customUser: User = {
+    _id,
+    email,
+    username,
+    nickname,
+    introduce,
+    image
+  };
+
+  return customUser;
+};
+
+export default parseUser;

--- a/src/pages/Post/index.tsx
+++ b/src/pages/Post/index.tsx
@@ -12,7 +12,7 @@ import useAuthCheckQuery from '@/apis/queries/useAuthCheckQuery';
 const Post = () => {
   const { postId } = useParams();
 
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const { isOpen: isCommentWriteOpen, onOpen: onCommentWriteOpen, onClose: onCommentWriteClose } = useDisclosure();
   const { data: postData } = usePostDetailQuery(postId ?? '');
   const { data: userData } = useAuthCheckQuery();
 
@@ -43,11 +43,11 @@ const Post = () => {
           </AnnouncementText>
           {isAuthor && <ListButton />}
         </Box>
-        <CommentBoard onOpen={onOpen} />
+        <CommentBoard onOpen={onCommentWriteOpen} />
         <Heading mb="1rem">{postData?.title}</Heading>
         <DescriptionText>{postData?.content}</DescriptionText>
       </VStack>
-      <CommentWriteModal isOpen={isOpen} onClose={onClose} />
+      <CommentWriteModal isOpen={isCommentWriteOpen} onClose={onCommentWriteClose} />
     </>
   );
 };

--- a/src/pages/Post/index.tsx
+++ b/src/pages/Post/index.tsx
@@ -1,5 +1,5 @@
-import { Box, Heading, VStack, useDisclosure } from '@chakra-ui/react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { Box, Heading, Text, VStack, useDisclosure } from '@chakra-ui/react';
+import { useParams } from 'react-router-dom';
 import AnnouncementText from './components/AnnouncementText';
 import ListButton from './components/ListButton';
 import DescriptionText from './components/DescriptionText';
@@ -11,10 +11,9 @@ import useAuthCheckQuery from '@/apis/queries/useAuthCheckQuery';
 
 const Post = () => {
   const { postId } = useParams();
-  const navigate = useNavigate();
 
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const { data: postData } = usePostDetailQuery(parseInt(postId ?? '0', 16));
+  const { data: postData } = usePostDetailQuery(postId ?? '');
   const { data: userData } = useAuthCheckQuery();
 
   const isAuthor = !!userData && !!postData && userData._id === postData.author._id;
@@ -30,17 +29,23 @@ const Post = () => {
         backgroundRepeat="no-repeat">
         <Box w="100%">
           <AnnouncementText mb="1rem">
-            원하는 위치를 클릭해서 {postData?.author.fullName} 님의 머쓱이에게 편지를 남겨주세요.
+            {isAuthor ? (
+              <>
+                {postData?.author.username} 님에게{' '}
+                <Text display="inline" color="red.400">
+                  {postData?.comments.length}
+                </Text>
+                개의 편지가 전달됐어요!
+              </>
+            ) : (
+              `원하는 위치를 클릭해서 ${postData?.author.username} 님의 머쓱이에게 편지를 남겨주세요.`
+            )}
           </AnnouncementText>
-          <ListButton />
+          {isAuthor && <ListButton />}
         </Box>
         <CommentBoard onOpen={onOpen} />
         <Heading mb="1rem">{postData?.title}</Heading>
-        <DescriptionText>
-          안녕하세요! 피드백을 받고 싶은 머쓱이 입니다.안녕하세요! 피드백을 받고 싶은 머쓱이 입니다.안녕하세요! 피드백을
-          받고 싶은 머쓱이 입니다.안녕하세요! 피드백을 받고 싶은 머쓱이 입니다.안녕하세요! 피드백을 받고 싶은 머쓱이
-          입니다.
-        </DescriptionText>
+        <DescriptionText>{postData?.content}</DescriptionText>
       </VStack>
       <CommentWriteModal isOpen={isOpen} onClose={onClose} />
     </>

--- a/src/pages/Post/index.tsx
+++ b/src/pages/Post/index.tsx
@@ -1,15 +1,23 @@
 import { Box, Heading, VStack, useDisclosure } from '@chakra-ui/react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import AnnouncementText from './components/AnnouncementText';
 import ListButton from './components/ListButton';
 import DescriptionText from './components/DescriptionText';
 import BackgroundHome from '@/assets/images/background_home.png';
 import CommentBoard from './components/CommentBoard';
 import CommentWriteModal from './components/CommentWriteModal';
+import usePostDetailQuery from '@/apis/queries/usePostDetailQuery';
+import useAuthCheckQuery from '@/apis/queries/useAuthCheckQuery';
 
 const Post = () => {
   const { postId } = useParams();
+  const navigate = useNavigate();
+
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const { data: postData } = usePostDetailQuery(parseInt(postId ?? '0', 16));
+  const { data: userData } = useAuthCheckQuery();
+
+  const isAuthor = !!userData && !!postData && userData._id === postData.author._id;
 
   return (
     <>
@@ -22,12 +30,12 @@ const Post = () => {
         backgroundRepeat="no-repeat">
         <Box w="100%">
           <AnnouncementText mb="1rem">
-            원하는 위치를 클릭해서 {postId} 님의 머쓱이에게 편지를 남겨주세요.
+            원하는 위치를 클릭해서 {postData?.author.fullName} 님의 머쓱이에게 편지를 남겨주세요.
           </AnnouncementText>
           <ListButton />
         </Box>
         <CommentBoard onOpen={onOpen} />
-        <Heading mb="1rem">{postId}의 머쓱이</Heading>
+        <Heading mb="1rem">{postData?.title}</Heading>
         <DescriptionText>
           안녕하세요! 피드백을 받고 싶은 머쓱이 입니다.안녕하세요! 피드백을 받고 싶은 머쓱이 입니다.안녕하세요! 피드백을
           받고 싶은 머쓱이 입니다.안녕하세요! 피드백을 받고 싶은 머쓱이 입니다.안녕하세요! 피드백을 받고 싶은 머쓱이

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,36 +1,37 @@
-export interface User {
+export interface User extends UserFullName {
   _id: string;
   email: string;
+  image: string; // default: 기본 이미지
+  posts: string[]; // 포스트 id 목록
+  comments: string[]; // 댓글 id 목록
+}
+
+export interface UserFullName {
   username: string; // 사용자 실명
-  nickname: string;
-  introduce: string;
-  image: string;
+  introduce: string; // default: "안녕하세요 000입니다"
+  slackId?: string; // default: undefined
+  slackWorkspace?: 'Frontend' | 'Backend'; // default: undefined
 }
 
-export interface customUserFullName {
-  username: string;
-  nickname: string;
-  introduce: string;
-}
-
-export interface Post extends customPostTitle {
+export interface Post extends PostTitle {
   _id: string;
   comments: Comment[];
   author: User;
 }
 
-export interface customPostTitle {
-  title: string;
-  content: string;
-  musseukId: string;
+export interface PostTitle {
+  title: string; // 머쓱이 제목, default: "머쓱이"
+  content: string; // 소개글, default: ""
+  musseukImageName: string; // 머쓱이 이미지 파일 이름
 }
 
-export interface Comment extends customCommentComment {
+export interface Comment extends CommentField {
   _id: string;
 }
 
-export interface customCommentComment {
-  content: string;
-  pos: [number, number];
-  nickname: string;
+export interface CommentField {
+  content: string; // default: ""
+  pos: [number, number]; // 댓글 좌표(백분율), default: [0, 0]
+  nickname: string; // default: "익명의 머쓱이"
+  decorationImageName: string; // 장식 이미지 파일 이름, default: ""
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,7 +22,7 @@ export interface Post extends PostTitle {
 export interface PostTitle {
   title: string; // 머쓱이 제목, default: "머쓱이"
   content: string; // 소개글, default: ""
-  musseukImageName: string; // 머쓱이 이미지 파일 이름
+  musseukImageName: string; // 머쓱이 이미지 파일 이름, default: "musseuk_default"
 }
 
 export interface Comment extends CommentField {
@@ -33,5 +33,5 @@ export interface CommentField {
   content: string; // default: ""
   pos: [number, number]; // 댓글 좌표(백분율), default: [0, 0]
   nickname: string; // default: "익명의 머쓱이"
-  decorationImageName: string; // 장식 이미지 파일 이름, default: ""
+  decorationImageName: string; // 장식 이미지 파일 이름, default: "decoration_soju1"
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,8 +2,8 @@ export interface User extends UserFullName {
   _id: string;
   email: string;
   image: string; // default: 기본 이미지
-  posts: string[]; // 포스트 id 목록
-  comments: string[]; // 댓글 id 목록
+  postCount: number; // 총 포스트 개수
+  commentCount: number; // 본인이 작성한 총 댓글 개수
 }
 
 export interface UserFullName {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,3 +6,31 @@ export interface User {
   introduce: string;
   image: string;
 }
+
+export interface customUserFullName {
+  username: string;
+  nickname: string;
+  introduce: string;
+}
+
+export interface Post extends customPostTitle {
+  _id: string;
+  comments: Comment[];
+  author: User;
+}
+
+export interface customPostTitle {
+  title: string;
+  content: string;
+  musseukId: string;
+}
+
+export interface Comment extends customCommentComment {
+  _id: string;
+}
+
+export interface customCommentComment {
+  content: string;
+  pos: [number, number];
+  nickname: string;
+}


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, hotfix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈번호를 작성해주세요 ex) #11 -->
- close #60

## ✅ 작업 사항 <!-- 가능한 구체적으로 작성해주세요 -->
- 포스트 페이지에 내용을 가져오기 위해 `usePostDetailQuery`를 구현했어요.
- API에서 받아온 응답을 실제 사용할 데이터로 가공하기 위해 `@/apis/utils`를 만들고 `parsePost` 함수를 구현했어요.
- `parsePost` 함수 내에서 Author와 Comment 데이터 가공을 위해 `parseUser`, `parseComment` 함수도 구현했어요.
- 실제 사용할 데이터들의 타입은 `@/types/index.ts` 에 작성했어요.
- 포스트 페이지에서 작성자 여부에 따라 조건부 UI를 구현했어요.

## 👩‍💻 공유 포인트 및 논의 사항 
- query에서 데이터를 가공하고 내려주면 좋을 것 같아서 parse 함수를 query 함수 내부에서 사용했는데 괜찮을까요?
- `User`의 `fullName` 나 `Post`의 `title` 필드처럼 JSON 형태로 넣었어야 하는 필드에 일반 string을 넣었다면 포스트 페이지에서 `undefined`가 출력돼요. 어느 필드에 어떤 JSON을 넣어야 하는지 논의가 필요할 것 같아요.