### PR TITLE
feature: 슬랙 인증 Confirmation 로직 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "qs": "^6.11.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-error-boundary": "^4.0.11",
         "react-hook-form": "^7.46.0",
         "react-icons": "^4.11.0",
         "react-router-dom": "^6.15.0",
@@ -5908,6 +5909,17 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.11.tgz",
+      "integrity": "sha512-U13ul67aP5DOSPNSCWQ/eO0AQEYzEFkVljULQIjMV0KlffTAhxuDoBKdO0pb/JZ8mDhMKFZ9NZi0BmLGUiNphw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-fast-compare": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "dotenv": "^16.3.1",
         "framer-motion": "^10.16.3",
         "lodash": "^4.17.21",
+        "qs": "^6.11.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.46.0",
@@ -31,6 +32,7 @@
       "devDependencies": {
         "@tanstack/eslint-plugin-query": "^4.34.1",
         "@types/node": "^20.5.9",
+        "@types/qs": "^6.9.8",
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
         "@typescript-eslint/eslint-plugin": "^6.5.0",
@@ -2439,6 +2441,12 @@
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
       "devOptional": true
     },
+    "node_modules/@types/qs": {
+      "version": "6.9.8",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.8.tgz",
+      "integrity": "sha512-u95svzDlTysU5xecFNTgfFG5RUWu1A9P0VzgpcIiGZA9iraHOdSzcxMxQ55DyeRaGCSxQi7LxXDI4rzq/MYfdg==",
+      "dev": true
+    },
     "node_modules/@types/react": {
       "version": "18.2.21",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.21.tgz",
@@ -3073,7 +3081,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -4280,7 +4287,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
       "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -4465,7 +4471,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
       "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -4477,7 +4482,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -5471,7 +5475,6 @@
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
       "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5837,6 +5840,20 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
+      "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -6438,7 +6455,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dotenv": "^16.3.1",
     "framer-motion": "^10.16.3",
     "lodash": "^4.17.21",
+    "qs": "^6.11.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.46.0",
@@ -34,6 +35,7 @@
   "devDependencies": {
     "@tanstack/eslint-plugin-query": "^4.34.1",
     "@types/node": "^20.5.9",
+    "@types/qs": "^6.9.8",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
     "@typescript-eslint/eslint-plugin": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "qs": "^6.11.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-error-boundary": "^4.0.11",
     "react-hook-form": "^7.46.0",
     "react-icons": "^4.11.0",
     "react-router-dom": "^6.15.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,28 +11,33 @@ import Search from './pages/Search';
 import ChangePassword from './pages/ChangePassword';
 import SettingSlack from './pages/Setting/Slack';
 import NotFound from './pages/NotFound';
-import SlackConfirmation from './pages/Setting/SlackConfirmation';
+import React, { Suspense } from 'react';
+import Loading from './components/Loading';
+
+const SlackConfirmation = React.lazy(() => import('./pages/Setting/SlackConfirmation'));
 
 const App = () => {
   useAuthCheckQuery();
 
   return (
     <Router>
-      <Routes>
-        <Route element={<MainLayout />}>
-          <Route path="/" element={<Main />} />
-          <Route path="/post/:postId" element={<Post />} />
-          <Route path="/newpost" element={<NewPost />} />
-          <Route path="/profile/:userId" element={<Profile />} />
-          <Route path="/search/:keyword" element={<Search />} />
-          <Route path="/setting/slack" element={<SettingSlack />} />
-          <Route path="/changePassword" element={<ChangePassword />} />
-          <Route path="/setting/slack/confirmation" element={<SlackConfirmation />} />
-        </Route>
-        <Route path="/signin" element={<SignIn />} />
-        <Route path="/signup" element={<SignUp />} />
-        <Route path="*" element={<NotFound />} />
-      </Routes>
+      <Suspense fallback={<Loading />}>
+        <Routes>
+          <Route element={<MainLayout />}>
+            <Route path="/" element={<Main />} />
+            <Route path="/post/:postId" element={<Post />} />
+            <Route path="/newpost" element={<NewPost />} />
+            <Route path="/profile/:userId" element={<Profile />} />
+            <Route path="/search/:keyword" element={<Search />} />
+            <Route path="/setting/slack" element={<SettingSlack />} />
+            <Route path="/changePassword" element={<ChangePassword />} />
+            <Route path="/setting/slack/confirmation" element={<SlackConfirmation />} />
+          </Route>
+          <Route path="/signin" element={<SignIn />} />
+          <Route path="/signup" element={<SignUp />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </Suspense>
     </Router>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,33 +11,28 @@ import Search from './pages/Search';
 import ChangePassword from './pages/ChangePassword';
 import SettingSlack from './pages/Setting/Slack';
 import NotFound from './pages/NotFound';
-import React, { Suspense } from 'react';
-import Loading from './components/Loading';
-
-const SlackConfirmation = React.lazy(() => import('./pages/Setting/SlackConfirmation'));
+import SlackConfirmationWrapper from './pages/Setting/SlackConfirmation';
 
 const App = () => {
   useAuthCheckQuery();
 
   return (
     <Router>
-      <Suspense fallback={<Loading />}>
-        <Routes>
-          <Route element={<MainLayout />}>
-            <Route path="/" element={<Main />} />
-            <Route path="/post/:postId" element={<Post />} />
-            <Route path="/newpost" element={<NewPost />} />
-            <Route path="/profile/:userId" element={<Profile />} />
-            <Route path="/search/:keyword" element={<Search />} />
-            <Route path="/setting/slack" element={<SettingSlack />} />
-            <Route path="/changePassword" element={<ChangePassword />} />
-            <Route path="/setting/slack/confirmation" element={<SlackConfirmation />} />
-          </Route>
-          <Route path="/signin" element={<SignIn />} />
-          <Route path="/signup" element={<SignUp />} />
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </Suspense>
+      <Routes>
+        <Route element={<MainLayout />}>
+          <Route path="/" element={<Main />} />
+          <Route path="/post/:postId" element={<Post />} />
+          <Route path="/newpost" element={<NewPost />} />
+          <Route path="/profile/:userId" element={<Profile />} />
+          <Route path="/search/:keyword" element={<Search />} />
+          <Route path="/setting/slack" element={<SettingSlack />} />
+          <Route path="/changePassword" element={<ChangePassword />} />
+          <Route path="/setting/slack/confirmation" element={<SlackConfirmationWrapper />} />
+        </Route>
+        <Route path="/signin" element={<SignIn />} />
+        <Route path="/signup" element={<SignUp />} />
+        <Route path="*" element={<NotFound />} />
+      </Routes>
     </Router>
   );
 };

--- a/src/apis/queries/useSlackTokenCheckQuery.ts
+++ b/src/apis/queries/useSlackTokenCheckQuery.ts
@@ -1,12 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 import { slackInstance } from '@/apis/instance';
 import queryKey from '@/apis/queryKeys';
-import { UserResponse } from '../types';
 import storage from '@/utils/storage';
 import { AUTH_TOKEN } from '@/constants/storageKey';
+import { User } from '@/types';
 
 type VerifyResponse = {
-  user: UserResponse;
+  user: User;
   token: string;
 };
 
@@ -17,7 +17,7 @@ export const getTokenResult = async (slackToken: string) => {
 };
 
 const useSlackTokenCheckQuery = (slackToken: string) => {
-  return useQuery<VerifyResponse>({
+  return useQuery<User>({
     // eslint-disable-next-line @tanstack/query/exhaustive-deps
     queryKey: queryKey.auth,
     queryFn: () => getTokenResult(slackToken)

--- a/src/apis/queries/useSlackTokenCheckQuery.ts
+++ b/src/apis/queries/useSlackTokenCheckQuery.ts
@@ -20,7 +20,8 @@ const useSlackTokenCheckQuery = (slackToken: string) => {
   return useQuery<User>({
     // eslint-disable-next-line @tanstack/query/exhaustive-deps
     queryKey: queryKey.auth,
-    queryFn: () => getTokenResult(slackToken)
+    queryFn: () => getTokenResult(slackToken),
+    suspense: true
   });
 };
 

--- a/src/apis/queries/useSlackTokenCheckQuery.ts
+++ b/src/apis/queries/useSlackTokenCheckQuery.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query';
+import { slackInstance } from '@/apis/instance';
+import queryKey from '@/apis/queryKeys';
+import { UserResponse } from '../types';
+import storage from '@/utils/storage';
+import { AUTH_TOKEN } from '@/constants/storageKey';
+
+type VerifyResponse = {
+  user: UserResponse;
+  token: string;
+};
+
+export const getTokenResult = async (slackToken: string) => {
+  const { data } = await slackInstance.get<VerifyResponse>(`/slack/verification/user?token=${slackToken}`);
+  storage('session').setItem(AUTH_TOKEN, data.token);
+  return data.user;
+};
+
+const useSlackTokenCheckQuery = (slackToken: string) => {
+  return useQuery<VerifyResponse>({
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
+    queryKey: queryKey.auth,
+    queryFn: () => getTokenResult(slackToken)
+  });
+};
+
+export default useSlackTokenCheckQuery;

--- a/src/components/Loading/index.tsx
+++ b/src/components/Loading/index.tsx
@@ -11,15 +11,9 @@ const Loading = () => {
       position="fixed"
       top="0"
       left="0"
-      bg="rgba(0, 0, 0, 0.5)" // 배경 색상 및 투명도 설정
+      bg="rgba(0, 0, 0, 0.5)"
       zIndex="9999">
-      <Spinner
-        thickness="4px"
-        speed="0.65s"
-        emptyColor="gray.200"
-        color="blue.500" // 로딩 스피너 색상 설정
-        size="xl" // 스피너 크기 설정
-      />
+      <Spinner thickness="4px" speed="0.65s" emptyColor="gray.200" color="green03" size="xl" />
     </Box>
   );
 };

--- a/src/components/Loading/index.tsx
+++ b/src/components/Loading/index.tsx
@@ -1,0 +1,27 @@
+import { Box, Spinner } from '@chakra-ui/react';
+
+const Loading = () => {
+  return (
+    <Box
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+      h="100vh"
+      w="100vw"
+      position="fixed"
+      top="0"
+      left="0"
+      bg="rgba(0, 0, 0, 0.5)" // 배경 색상 및 투명도 설정
+      zIndex="9999">
+      <Spinner
+        thickness="4px"
+        speed="0.65s"
+        emptyColor="gray.200"
+        color="blue.500" // 로딩 스피너 색상 설정
+        size="xl" // 스피너 크기 설정
+      />
+    </Box>
+  );
+};
+
+export default Loading;

--- a/src/pages/Search/index.tsx
+++ b/src/pages/Search/index.tsx
@@ -11,10 +11,10 @@ const Search = () => {
     <VStack spacing={12} mb={10}>
       <Box w="100%" bgGradient="linear-gradient(180deg, #C6FFC1 0%, #F5FFE2 100%)" p="3rem">
         <Heading mb={4}>데브코스 익명 편지 전송 서비스</Heading>
-        <br></br>
+        <br />
         <Text fontSize="xl">팀원들에게 전하지 못한 말들이 있어 아쉽지 않으셨나요?</Text>
         <Text fontSize="xl">다른 사람의 머쓱이에게 편지를 남겨보세요!</Text>
-        <br></br>
+        <br />
         <Text fontSize="xl"> 또는, 당신의 머쓱이를 만들어서 공유해보세요! </Text>
       </Box>
       <HStack gap={4}>

--- a/src/pages/Search/index.tsx
+++ b/src/pages/Search/index.tsx
@@ -10,12 +10,12 @@ const Search = () => {
   return (
     <VStack spacing={12} mb={10}>
       <Box w="100%" bgGradient="linear-gradient(180deg, #C6FFC1 0%, #F5FFE2 100%)" p="3rem">
-        <Flex flexDirection={'column'} gap={4}>
-          <Heading mb={4}>데브코스 익명 편지 전송 서비스</Heading>
-          <Text fontSize="xl">팀원들에게 전하지 못한 말들이 있어 아쉽지 않으셨나요?</Text>
-          <Text fontSize="xl">다른 사람의 머쓱이에게 편지를 남겨보세요!</Text>
-          <Text fontSize="xl"> 또는, 당신의 머쓱이를 만들어서 공유해보세요! </Text>
-        </Flex>
+        <Heading mb={4}>데브코스 익명 편지 전송 서비스</Heading>
+        <br></br>
+        <Text fontSize="xl">팀원들에게 전하지 못한 말들이 있어 아쉽지 않으셨나요?</Text>
+        <Text fontSize="xl">다른 사람의 머쓱이에게 편지를 남겨보세요!</Text>
+        <br></br>
+        <Text fontSize="xl"> 또는, 당신의 머쓱이를 만들어서 공유해보세요! </Text>
       </Box>
       <HStack gap={4}>
         <Text fontWeight={'bold'} fontSize={'2xl'}>

--- a/src/pages/Setting/SlackConfirmation/index.tsx
+++ b/src/pages/Setting/SlackConfirmation/index.tsx
@@ -5,6 +5,10 @@ import { Navigate, useNavigate } from 'react-router-dom';
 import useSlackTokenCheckQuery from '@/apis/queries/useSlackTokenCheckQuery';
 import qs from 'qs';
 import useAuthCheckQuery from '@/apis/queries/useAuthCheckQuery';
+import { Suspense } from 'react';
+import Loading from '@/components/Loading';
+import { ErrorBoundary } from 'react-error-boundary';
+import NotFound from '@/pages/NotFound';
 
 const SlackConfirmation = () => {
   const navigate = useNavigate();
@@ -36,4 +40,14 @@ const SlackConfirmation = () => {
   );
 };
 
-export default SlackConfirmation;
+const SlackConfirmationWrapper = () => {
+  return (
+    <ErrorBoundary fallback={<NotFound />}>
+      <Suspense fallback={<Loading />}>
+        <SlackConfirmation />
+      </Suspense>
+    </ErrorBoundary>
+  );
+};
+
+export default SlackConfirmationWrapper;

--- a/src/pages/Setting/SlackConfirmation/index.tsx
+++ b/src/pages/Setting/SlackConfirmation/index.tsx
@@ -1,10 +1,9 @@
 import PageTemplateWithHeader from '@/components/WhiteCard/PageTemplateWithHeader';
 import { Heading, Image, Text, Button } from '@chakra-ui/react';
 import musseuk_box from '@/assets/images/musseuk_box.png';
-import { Navigate, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import useSlackTokenCheckQuery from '@/apis/queries/useSlackTokenCheckQuery';
 import qs from 'qs';
-import useAuthCheckQuery from '@/apis/queries/useAuthCheckQuery';
 import { Suspense } from 'react';
 import Loading from '@/components/Loading';
 import { ErrorBoundary } from 'react-error-boundary';
@@ -16,9 +15,6 @@ const SlackConfirmation = () => {
   const slackToken = String(queryString.token);
 
   const { data: slackResponseData } = useSlackTokenCheckQuery(slackToken);
-  const { data: userData } = useAuthCheckQuery();
-
-  if (!slackResponseData && !userData) return <Navigate to={'/notFound'} />;
 
   return (
     <PageTemplateWithHeader>

--- a/src/pages/Setting/SlackConfirmation/index.tsx
+++ b/src/pages/Setting/SlackConfirmation/index.tsx
@@ -1,39 +1,38 @@
 import PageTemplateWithHeader from '@/components/WhiteCard/PageTemplateWithHeader';
 import { Heading, Image, Text, Button } from '@chakra-ui/react';
 import musseuk_box from '@/assets/images/musseuk_box.png';
-import { useNavigate } from 'react-router-dom';
-import Loading from '@/components/Loading';
-import { Suspense, useState } from 'react';
+import { Navigate, useNavigate } from 'react-router-dom';
 import useSlackTokenCheckQuery from '@/apis/queries/useSlackTokenCheckQuery';
 import qs from 'qs';
+import useAuthCheckQuery from '@/apis/queries/useAuthCheckQuery';
 
 const SlackConfirmation = () => {
-  //const [isLoading, setIsLoading] = useState(false);
   const navigate = useNavigate();
   const queryString = qs.parse(window.location.search, { ignoreQueryPrefix: true });
   const slackToken = String(queryString.token);
 
-  const { data } = useSlackTokenCheckQuery(slackToken);
+  const { data: slackResponseData } = useSlackTokenCheckQuery(slackToken);
+  const { data: userData } = useAuthCheckQuery();
+
+  if (!slackResponseData && !userData) return <Navigate to={'/notFound'} />;
 
   return (
-    <Suspense fallback={<Loading />}>
-      <PageTemplateWithHeader>
-        <Image maxW="56" src={musseuk_box} alt="머쓱이" />
-        <Heading mt={'2rem'} fontSize={'2xl'} textAlign="center" wordBreak={'keep-all'}>
-          🎉 슬랙 인증이 완료되었습니다 🎉
-        </Heading>
-        <Text color="gray.500">이제부터 편지 수신 알람을 슬랙에서 받을 수 있습니다.</Text>
-        <Button
-          onClick={() => {
-            navigate('/');
-          }}
-          mt="24"
-          w="100%"
-          colorScheme="primary">
-          메인페이지로 돌아가기
-        </Button>
-      </PageTemplateWithHeader>
-    </Suspense>
+    <PageTemplateWithHeader>
+      <Image maxW="56" src={musseuk_box} alt="머쓱이" />
+      <Heading mt={'2rem'} fontSize={'2xl'} textAlign="center" wordBreak={'keep-all'}>
+        🎉 슬랙 인증이 완료되었습니다 🎉
+      </Heading>
+      <Text color="gray.500">이제부터 편지 수신 알람을 슬랙에서 받을 수 있습니다.</Text>
+      <Button
+        onClick={() => {
+          navigate('/');
+        }}
+        mt="24"
+        w="100%"
+        colorScheme="primary">
+        메인페이지로 돌아가기
+      </Button>
+    </PageTemplateWithHeader>
   );
 };
 

--- a/src/pages/Setting/SlackConfirmation/index.tsx
+++ b/src/pages/Setting/SlackConfirmation/index.tsx
@@ -2,27 +2,38 @@ import PageTemplateWithHeader from '@/components/WhiteCard/PageTemplateWithHeade
 import { Heading, Image, Text, Button } from '@chakra-ui/react';
 import musseuk_box from '@/assets/images/musseuk_box.png';
 import { useNavigate } from 'react-router-dom';
+import Loading from '@/components/Loading';
+import { Suspense, useState } from 'react';
+import useSlackTokenCheckQuery from '@/apis/queries/useSlackTokenCheckQuery';
+import qs from 'qs';
 
 const SlackConfirmation = () => {
+  //const [isLoading, setIsLoading] = useState(false);
   const navigate = useNavigate();
+  const queryString = qs.parse(window.location.search, { ignoreQueryPrefix: true });
+  const slackToken = String(queryString.token);
+
+  const { data } = useSlackTokenCheckQuery(slackToken);
 
   return (
-    <PageTemplateWithHeader>
-      <Image maxW="56" src={musseuk_box} alt="머쓱이" />
-      <Heading mt={'2rem'} fontSize={'2xl'} textAlign="center" wordBreak={'keep-all'}>
-        🎉 슬랙 인증이 완료되었습니다 🎉
-      </Heading>
-      <Text color="gray.500">이제부터 편지 수신 알람을 슬랙에서 받을 수 있습니다.</Text>
-      <Button
-        onClick={() => {
-          navigate('/');
-        }}
-        mt="24"
-        w="100%"
-        colorScheme="primary">
-        메인페이지로 돌아가기
-      </Button>
-    </PageTemplateWithHeader>
+    <Suspense fallback={<Loading />}>
+      <PageTemplateWithHeader>
+        <Image maxW="56" src={musseuk_box} alt="머쓱이" />
+        <Heading mt={'2rem'} fontSize={'2xl'} textAlign="center" wordBreak={'keep-all'}>
+          🎉 슬랙 인증이 완료되었습니다 🎉
+        </Heading>
+        <Text color="gray.500">이제부터 편지 수신 알람을 슬랙에서 받을 수 있습니다.</Text>
+        <Button
+          onClick={() => {
+            navigate('/');
+          }}
+          mt="24"
+          w="100%"
+          colorScheme="primary">
+          메인페이지로 돌아가기
+        </Button>
+      </PageTemplateWithHeader>
+    </Suspense>
   );
 };
 


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, hotfix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈번호를 작성해주세요 ex) #11 -->
- close #107

## ✅ 작업 사항 <!-- 가능한 구체적으로 작성해주세요 -->
- 테스트를 위해 임의로 Loading 컴포넌트를 만들었습니다 (디자인 회의 후 변경 될 예정)
- 슬랙 인증 리다이랙트 페이지 url에서 일회용 토큰 queryString을 parse해왔습니다
- 다시 슬랙 서버에 일회용 토큰을 params로 보내줌으로써 GET 요청으로 accesstoken을 받아 세션 스토리지에 저장해줍니다.
- Suspense를 이용해서 api와 관련된 작업이 처리되기 전까지는 SlackConfirmation Page가 나오지 않고 로딩처리가 되도록 했습니다.
- useAuthCheckQuery, useSlackTokenCheckQuery을 호출하여 반환되는 데이터가 없다면 404페이지로 이동합니다.

## 👩‍💻 공유 포인트 및 논의 사항 
내일부터 반응형, QA 작업과 더불어 로딩 관련된 작업도 같이 논의해봐야할 것 같아요!