### PR TITLE
refactor: 사용자 인증 관련 query, mutation 훅 리팩토링

### DIFF
--- a/src/apis/mutations/useSignOutMutation.ts
+++ b/src/apis/mutations/useSignOutMutation.ts
@@ -6,16 +6,18 @@ import queryKey from '../queryKeys';
 
 const postSignOut = async () => {
   const { data } = await authInstance.post('/logout');
+
   return data;
 };
 
 const useSignOutMutation = () => {
   const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: postSignOut,
     onMutate: () => {
-      queryClient.setQueryData(queryKey.auth, null);
       storage('session').removeItem(AUTH_TOKEN);
+      queryClient.removeQueries(queryKey.auth);
     }
   });
 };

--- a/src/apis/mutations/useSigninMutation.ts
+++ b/src/apis/mutations/useSigninMutation.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 import { baseInstance } from '@/apis/instance';
 import queryKey from '@/apis/queryKeys';
 import storage from '@/utils/storage';
@@ -25,7 +26,7 @@ const postLogin = async (params: RequestData) => {
 const useSigninMutation = () => {
   const queryClient = useQueryClient();
 
-  return useMutation({
+  return useMutation<ResponseData, AxiosError, RequestData>({
     mutationFn: postLogin,
     onSuccess: (data) => {
       storage('session').setItem(AUTH_TOKEN, data.token);

--- a/src/apis/mutations/useSigninMutation.ts
+++ b/src/apis/mutations/useSigninMutation.ts
@@ -1,10 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { AxiosError } from 'axios';
 import { baseInstance } from '@/apis/instance';
 import queryKey from '@/apis/queryKeys';
 import storage from '@/utils/storage';
 import { AUTH_TOKEN } from '@/constants/storageKey';
-import type { User } from '@/types';
+import parseUser from '../utils/parseUser';
+import { UserResponse } from '../types';
 
 interface RequestData {
   email: string;
@@ -12,12 +12,12 @@ interface RequestData {
 }
 
 interface ResponseData {
-  user: User;
+  user: UserResponse;
   token: string;
 }
 
 const postLogin = async (params: RequestData) => {
-  const { data } = await baseInstance.post('/login', params);
+  const { data } = await baseInstance.post<ResponseData>('/login', params);
 
   return data;
 };
@@ -25,11 +25,11 @@ const postLogin = async (params: RequestData) => {
 const useSigninMutation = () => {
   const queryClient = useQueryClient();
 
-  return useMutation<ResponseData, AxiosError, RequestData>({
+  return useMutation({
     mutationFn: postLogin,
     onSuccess: (data) => {
-      queryClient.setQueryData(queryKey.auth, data.user);
       storage('session').setItem(AUTH_TOKEN, data.token);
+      queryClient.setQueryData(queryKey.auth, parseUser(data.user));
     }
   });
 };

--- a/src/apis/mutations/useSignupMutation.ts
+++ b/src/apis/mutations/useSignupMutation.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 import { baseInstance } from '@/apis/instance';
 import queryKey from '@/apis/queryKeys';
 import storage from '@/utils/storage';
@@ -44,7 +45,7 @@ const postSignup = async (customParams: CustomRequestData) => {
 const useSignupMutation = () => {
   const queryClient = useQueryClient();
 
-  return useMutation({
+  return useMutation<ResponseData, AxiosError, CustomRequestData>({
     mutationFn: postSignup,
     onSuccess: (data) => {
       storage('session').setItem(AUTH_TOKEN, data.token);

--- a/src/apis/queries/useAuthCheckQuery.ts
+++ b/src/apis/queries/useAuthCheckQuery.ts
@@ -17,6 +17,7 @@ const useAuthCheckQuery = (options?: QueryOptions<User>) => {
   return useQuery<User>({
     queryKey: queryKey.auth,
     queryFn: getAuthUser,
+    staleTime: Infinity,
     ...options
   });
 };

--- a/src/apis/queries/useAuthCheckQuery.ts
+++ b/src/apis/queries/useAuthCheckQuery.ts
@@ -1,6 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
 import { authInstance } from '@/apis/instance';
 import queryKey from '@/apis/queryKeys';
+import parseUser from '@/apis/utils/parseUser';
+import type { User } from '@/types';
 import type { QueryOptions, UserResponse } from '@/apis/types';
 
 export const getAuthUser = async () => {
@@ -8,17 +10,13 @@ export const getAuthUser = async () => {
 
   if (data === '') throw new Error('Not authenticated yet');
 
-  return data;
+  return parseUser(data);
 };
 
-const useAuthCheckQuery = (options?: QueryOptions<UserResponse>) => {
-  return useQuery<UserResponse>({
+const useAuthCheckQuery = (options?: QueryOptions<User>) => {
+  return useQuery<User>({
     queryKey: queryKey.auth,
     queryFn: getAuthUser,
-    cacheTime: Infinity,
-    retry: 0,
-    refetchOnReconnect: false,
-    refetchOnWindowFocus: false,
     ...options
   });
 };


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, hotfix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈번호를 작성해주세요 ex) #11 -->
- close #110 

## ✅ 작업 사항 <!-- 가능한 구체적으로 작성해주세요 -->
사용자 인증과 관련한 훅에서 여러 문제를 개선하기 위한 작업을 진행했어요.

### useAuthCheckQuery
- 네트워크가 불안정할 때 요청에 실패하면 더 이상 로그인 된 유저의 정보를 가져오지 못하는 문제가 있었어요.
  - 그래서 `retry`, `refetchOn~~~` 옵션을 제거했어요.,
- 이미 인증된 데이터가 있으면 더 이상 네트워크 요청을 발생하지 않기를 의도했었는데, `cacheTime` 이 아니라 `staleTime` 이 원하는 옵션이었어서 교체했어요.
- SNS 서버에서 날아온 미가공 상태의 `UserResponse` 타입을 데이터로 저장하고 있었어서, 파싱된 형태의 데이터인 `User` 타입의 데이터를 저장하도록 교체했어요.

### useSigninMutation
- SNS 서버에서 날아온 미가공 상태의 `UserResponse` 타입을 데이터로 저장하고 있었어서, 파싱된 형태의 데이터인 `User` 타입의 데이터를 저장하도록 교체했어요.

### useSignupMutation
- 회원가입시 introduce 필드는 받지 않기 때문에 제외했어요.
- SNS 서버에서 날아온 미가공 상태의 `UserResponse` 타입을 데이터로 저장하고 있었어서, 파싱된 형태의 데이터인 `User` 타입의 데이터를 저장하도록 교체했어요.

### useSignoutMutation
- ['auth'] 쿼리 키에 해당하는 데이터를 null로 교체하는게 아니라, 아예 `removeQueries()` 로 데이터를 지웠어요.


## 👩‍💻 공유 포인트 및 논의 사항 
