### PR TITLE
feature: 로그인 페이지 리다이렉션 기능

### DIFF
--- a/src/pages/Signin/index.tsx
+++ b/src/pages/Signin/index.tsx
@@ -1,11 +1,12 @@
-import { Link, useNavigate, Navigate } from 'react-router-dom';
+import { Link, Navigate } from 'react-router-dom';
 import { useForm, SubmitHandler, SubmitErrorHandler } from 'react-hook-form';
+import qs from 'qs';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { Image, Heading, Button, Text, Flex } from '@chakra-ui/react';
 import { EmailIcon } from '@chakra-ui/icons';
-import useAuthCheckQuery from '@/apis/queries/useAuthCheckQuery';
 import useSigninMutation from '@/apis/mutations/useSigninMutation';
+import useIsNotLoggedIn from '@/hooks/useIsNotLoggedIn';
 import musseuk from '@/assets/images/musseuk_hood.png';
 import PageTemplate from '@/components/WhiteCard/PageTemplate';
 import InputField from '@/pages/Signup/components/InputField';
@@ -21,9 +22,10 @@ const formSchema = z.object({ email: z.string().email(), password: z.string() })
 type Inputs = z.infer<typeof formSchema>;
 
 const SignIn = () => {
-  const navigate = useNavigate();
+  const queryString = qs.parse(window.location.search, { ignoreQueryPrefix: true });
+  const redirectTo = String(queryString.redirectTo || links.main);
 
-  const { data: user } = useAuthCheckQuery();
+  const { isNotLoggedIn } = useIsNotLoggedIn();
   const { mutate } = useSigninMutation();
 
   const {
@@ -39,7 +41,6 @@ const SignIn = () => {
     mutate(
       { email: data.email, password: data.password },
       {
-        onSuccess: () => navigate(links.main),
         onError: (error) => {
           const errorMessage = typeof error.response?.data === 'string' ? error.response?.data : '';
           setError('email', { type: 'server', message: errorMessage });
@@ -51,7 +52,7 @@ const SignIn = () => {
 
   const onError: SubmitErrorHandler<Inputs> = (errors) => console.error(errors);
 
-  if (user) return <Navigate to={links.main} />;
+  if (!isNotLoggedIn) return <Navigate to={redirectTo} />;
 
   return (
     <PageTemplate onSubmit={handleSubmit(onSubmit, onError)}>

--- a/src/pages/Signup/index.tsx
+++ b/src/pages/Signup/index.tsx
@@ -1,11 +1,11 @@
-import { Link, useNavigate, Navigate } from 'react-router-dom';
+import { Link, Navigate } from 'react-router-dom';
 import { useForm, SubmitHandler, SubmitErrorHandler } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { Box, Button, Icon, Heading, Text, Image, useBoolean } from '@chakra-ui/react';
 import { ViewIcon, ViewOffIcon } from '@chakra-ui/icons';
-import useAuthCheckQuery from '@/apis/queries/useAuthCheckQuery';
 import useSignupMutation from '@/apis/mutations/useSignupMutation';
+import useIsNotLoggedIn from '@/hooks/useIsNotLoggedIn';
 import musseuk from '@/assets/images/musseuk_hood.png';
 import PageTemplate from '@/components/WhiteCard/PageTemplate';
 import { isPasswordTooShort, isPasswordContainNumber } from './helpers/password';
@@ -39,13 +39,12 @@ const formSchema = z
 type Inputs = z.infer<typeof formSchema>;
 
 const SignUp = () => {
-  const navigate = useNavigate();
-
-  const { data: user } = useAuthCheckQuery();
+  const { isNotLoggedIn } = useIsNotLoggedIn();
   const { mutate } = useSignupMutation();
 
   const [showPassword, setShowPassword] = useBoolean(false);
   const [showConfirmPassword, setShowConfirmPassword] = useBoolean(false);
+
   const {
     register,
     handleSubmit,
@@ -55,13 +54,13 @@ const SignUp = () => {
   } = useForm<Inputs>({
     resolver: zodResolver(formSchema)
   });
+
   const password = watch('password');
 
   const onSubmit: SubmitHandler<Inputs> = (data) => {
     mutate(
       { email: data.email, password: data.password, username: data.username },
       {
-        onSuccess: () => navigate(links.main),
         onError: (error) => {
           const errorMessage = typeof error.response?.data === 'string' ? error.response?.data : '';
           setError('email', { type: 'server', message: errorMessage });
@@ -72,7 +71,7 @@ const SignUp = () => {
 
   const onError: SubmitErrorHandler<Inputs> = (errors) => console.error(errors);
 
-  if (user) return <Navigate to={links.main} />;
+  if (!isNotLoggedIn) return <Navigate to={links.main} />;
 
   return (
     <PageTemplate onSubmit={handleSubmit(onSubmit, onError)}>


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, hotfix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈번호를 작성해주세요 ex) #11 -->
- close #133 

## ✅ 작업 사항 <!-- 가능한 구체적으로 작성해주세요 -->
- 로그인 페이지에 queryString으로 redirectTo를 보내면 로그인 성공 후 해당 페이지로 이동하는 로직을 작성했어요.
- 로그인 페이지, 회원가입 페이지에서 로그인 성공 여부 체크를 `useIsNotLoggedIn` 훅을 사용하는 방식으로 변경했어요.

## 👩‍💻 공유 포인트 및 논의 사항 
리다이렉션할 페이지를 queryString 의 redirectTo 필드로 보내면 돼요.
ex) `navigate('/signin?redirectTo=/post/65096631f1c07c5a076321bd?commentId=asdfasdfasfafa')`