### PR TITLE
hotfix: 회원가입, 로그인, 비밀번호 변경 QA 반영

### DIFF
--- a/src/apis/mutations/useSignupMutation.ts
+++ b/src/apis/mutations/useSignupMutation.ts
@@ -28,7 +28,7 @@ interface ResponseData {
 const postSignup = async (customParams: CustomRequestData) => {
   const fullName: UserFullName = {
     username: customParams.username,
-    introduce: ''
+    introduce: `안녕하세요 ${customParams.username}입니다.`
   };
 
   const params: RequestData = {

--- a/src/pages/ChangePassword/index.tsx
+++ b/src/pages/ChangePassword/index.tsx
@@ -20,12 +20,12 @@ const formSchema = z
   .object({
     password: z
       .string()
-      .min(8, '8글자 이상으로만 입력할 수 있어요')
-      .refine((value) => /\d/.test(value), '숫자를 반드시 포함해야 해요'),
+      .min(8, '8글자 이상으로만 입력할 수 있습니다.')
+      .refine((value) => /\d/.test(value), '숫자를 반드시 포함해야 합니다.'),
     confirmPassword: z.string()
   })
   .refine((data) => data.password === data.confirmPassword, {
-    message: '비밀번호가 일치하지 않아요',
+    message: '비밀번호가 일치하지 않습니다.',
     path: ['confirmPassword']
   });
 
@@ -96,8 +96,8 @@ const ChangePassword = () => {
         icon={<Icon as={showPassword ? ViewOffIcon : ViewIcon} onClick={setShowPassword.toggle} />}
       />
       <Box w="100%" fontSize="sm">
-        {isPasswordTooShort(password) && <Text fontWeight="light">· 8글자 이상으로만 입력할 수 있어요</Text>}
-        {!isPasswordContainNumber(password) && <Text fontWeight="light">· 숫자를 반드시 포함해야 해요</Text>}
+        {isPasswordTooShort(password) && <Text fontWeight="light">· 8글자 이상으로만 입력할 수 있습니다.</Text>}
+        {!isPasswordContainNumber(password) && <Text fontWeight="light">· 숫자를 반드시 포함해야 합니다.</Text>}
       </Box>
       <InputField
         {...register('confirmPassword')}

--- a/src/pages/ChangePassword/index.tsx
+++ b/src/pages/ChangePassword/index.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate, Navigate } from 'react-router-dom';
+import { useNavigate, Navigate } from 'react-router-dom';
 import { useForm, SubmitHandler, SubmitErrorHandler } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -13,7 +13,6 @@ import { LinkTemplate } from '@/pages/Signup/templates';
 import PageTemplateWithHeader from '@/components/WhiteCard/PageTemplateWithHeader';
 
 const links = {
-  back: '..',
   signin: '/signin'
 };
 
@@ -63,7 +62,7 @@ const ChangePassword = () => {
             status: 'success',
             position: 'top'
           });
-          navigate(links.back);
+          navigate(-1);
         },
         onError: (error) => {
           const errorMessage = typeof error.response?.data === 'string' ? error.response?.data : '';
@@ -115,21 +114,20 @@ const ChangePassword = () => {
       </Button>
       <LinkTemplate>
         <Text color="gray.400">비밀번호 변경을 원하지 않으신가요?</Text>
-        <Link to={links.back}>
-          <Text
-            color="green.500"
-            _hover={{
-              color: 'green.600'
-            }}
-            _active={{
-              color: 'green.700'
-            }}
-            fontWeight="semibold"
-            cursor="pointer"
-            userSelect="none">
-            돌아가기
-          </Text>
-        </Link>
+        <Text
+          onClick={() => navigate(-1)}
+          color="green.500"
+          _hover={{
+            color: 'green.600'
+          }}
+          _active={{
+            color: 'green.700'
+          }}
+          fontWeight="semibold"
+          cursor="pointer"
+          userSelect="none">
+          돌아가기
+        </Text>
       </LinkTemplate>
     </PageTemplateWithHeader>
   );

--- a/src/pages/ChangePassword/index.tsx
+++ b/src/pages/ChangePassword/index.tsx
@@ -21,12 +21,12 @@ const formSchema = z
   .object({
     password: z
       .string()
-      .min(8, 'Length must be greater than 8 characters')
-      .refine((value) => /\d/.test(value), 'Password must contain numbers'),
+      .min(8, '8글자 이상으로만 입력할 수 있어요')
+      .refine((value) => /\d/.test(value), '숫자를 반드시 포함해야 해요'),
     confirmPassword: z.string()
   })
   .refine((data) => data.password === data.confirmPassword, {
-    message: 'Passwords do not match',
+    message: '비밀번호가 일치하지 않아요',
     path: ['confirmPassword']
   });
 
@@ -41,6 +41,7 @@ const ChangePassword = () => {
 
   const [showPassword, setShowPassword] = useBoolean(false);
   const [showConfirmPassword, setShowConfirmPassword] = useBoolean(false);
+
   const {
     register,
     handleSubmit,
@@ -49,6 +50,7 @@ const ChangePassword = () => {
   } = useForm<Inputs>({
     resolver: zodResolver(formSchema)
   });
+
   const password = watch('password');
 
   const onSubmit: SubmitHandler<Inputs> = (data) => {
@@ -83,36 +85,36 @@ const ChangePassword = () => {
     <PageTemplateWithHeader onSubmit={handleSubmit(onSubmit, onError)}>
       <Image maxW="32" src={musseuk} alt="머쓱이" />
       <Heading size="lg" textAlign="center">
-        Change Password
+        비밀번호 변경
       </Heading>
       <InputField
         {...register('password')}
         id="password"
         type={showPassword ? 'text' : 'password'}
-        label="Password"
+        label="비밀번호"
         placeholder="비밀번호를 입력해주세요"
         maxLength={30}
         icon={<Icon as={showPassword ? ViewOffIcon : ViewIcon} onClick={setShowPassword.toggle} />}
       />
       <Box w="100%" fontSize="sm">
-        {isPasswordTooShort(password) && <Text fontWeight="light">· Length must be greater than 8 characters</Text>}
-        {!isPasswordContainNumber(password) && <Text fontWeight="light">· Password must contain numbers</Text>}
+        {isPasswordTooShort(password) && <Text fontWeight="light">· 8글자 이상으로만 입력할 수 있어요</Text>}
+        {!isPasswordContainNumber(password) && <Text fontWeight="light">· 숫자를 반드시 포함해야 해요</Text>}
       </Box>
       <InputField
         {...register('confirmPassword')}
         id="confirm-password"
         type={showConfirmPassword ? 'text' : 'password'}
-        label="Confirm Password"
+        label="비밀번호 확인"
         placeholder="비밀번호를 재확인해주세요"
         maxLength={30}
         icon={<Icon as={showConfirmPassword ? ViewOffIcon : ViewIcon} onClick={setShowConfirmPassword.toggle} />}
         error={errors.confirmPassword}
       />
       <Button type="submit" mt="6" w="100%" colorScheme="primary">
-        Change password
+        비밀번호 변경
       </Button>
       <LinkTemplate>
-        <Text color="gray.400">Not want to change the password?</Text>
+        <Text color="gray.400">비밀번호 변경을 원하지 않으신가요?</Text>
         <Link to={links.back}>
           <Text
             color="green.500"
@@ -125,7 +127,7 @@ const ChangePassword = () => {
             fontWeight="semibold"
             cursor="pointer"
             userSelect="none">
-            Back
+            돌아가기
           </Text>
         </Link>
       </LinkTemplate>

--- a/src/pages/NotFound/index.tsx
+++ b/src/pages/NotFound/index.tsx
@@ -1,13 +1,11 @@
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { Flex, Button, Heading, Text, Image } from '@chakra-ui/react';
 import PageTemplateWithHeader from '@/components/WhiteCard/PageTemplateWithHeader';
 import notfound from '@/assets/images/404_notfound.png';
 
-const links = {
-  back: '..'
-};
-
 const NotFound = () => {
+  const navigate = useNavigate();
+
   return (
     <PageTemplateWithHeader>
       <Image
@@ -27,11 +25,9 @@ const NotFound = () => {
         <Text>아쉽지만</Text>
         <Text>여긴 당신이 찾는 주소가 아니에요.</Text>
       </Flex>
-      <Link css={{ width: '100%' }} to={links.back}>
-        <Button mt="6" w="100%" colorScheme="primary">
-          이전 페이지로 돌아가기
-        </Button>
-      </Link>
+      <Button mt="6" w="100%" colorScheme="primary" onClick={() => navigate(-1)}>
+        이전 페이지로 돌아가기
+      </Button>
     </PageTemplateWithHeader>
   );
 };

--- a/src/pages/Signin/index.tsx
+++ b/src/pages/Signin/index.tsx
@@ -63,7 +63,7 @@ const SignIn = () => {
   return (
     <PageTemplate onSubmit={handleSubmit(onSubmit, onError)}>
       <Image maxW="32" src={musseuk} alt="머쓱이" />
-      <Heading textAlign="center">Sign in</Heading>
+      <Heading textAlign="center">로그인</Heading>
       <Flex
         color="gray.500"
         justifyContent="center"
@@ -73,13 +73,13 @@ const SignIn = () => {
         fontSize="lg"
         textAlign="center"
         fontWeight="light">
-        Welcome to 머쓱레터 <EmailIcon />
+        당신의 마음을 전달하는 머쓱레터 <EmailIcon />
       </Flex>
       <InputField
         {...register('email')}
         id="email"
         type="email"
-        label="Email"
+        label="이메일"
         error={errors.email}
         placeholder="이메일을 입력해주세요"
       />
@@ -87,16 +87,16 @@ const SignIn = () => {
         {...register('password')}
         id="password"
         type="password"
-        label="Password"
+        label="비밀번호"
         error={errors.password}
         placeholder="비밀번호를 입력해주세요"
         maxLength={30}
       />
       <Button type="submit" mt="6" w="100%" colorScheme="primary">
-        Sign in
+        로그인
       </Button>
       <LinkTemplate>
-        <Text color="gray.400">No account yet?</Text>
+        <Text color="gray.400">아직 가입하지 않으셨나요?</Text>
         <Link to={links.signup}>
           <Text
             color="green.500"
@@ -109,7 +109,7 @@ const SignIn = () => {
             fontWeight="semibold"
             cursor="pointer"
             userSelect="none">
-            Create an account
+            회원가입
           </Text>
         </Link>
       </LinkTemplate>

--- a/src/pages/Signin/index.tsx
+++ b/src/pages/Signin/index.tsx
@@ -12,12 +12,19 @@ import PageTemplate from '@/components/WhiteCard/PageTemplate';
 import InputField from '@/pages/Signup/components/InputField';
 import { LinkTemplate } from '@/pages/Signup/templates';
 
+const ERROR_MESSAGE: {
+  [key: string]: string;
+} = {
+  'Your email and password combination does not match an account.':
+    '해당 이메일과 비밀번호로 일치하는 계정이 존재하지 않아요.'
+};
+
 const links = {
   main: '/',
   signup: '/signup'
 };
 
-const formSchema = z.object({ email: z.string().email('이메일 주소 형태로 입력해주세요.'), password: z.string() });
+const formSchema = z.object({ email: z.string().email('이메일 주소 형태로만 입력할 수 있어요'), password: z.string() });
 
 type Inputs = z.infer<typeof formSchema>;
 
@@ -41,8 +48,9 @@ const SignIn = () => {
     mutate(
       { email: data.email, password: data.password },
       {
-        onError: () => {
-          setError('email', { type: 'server', message: '해당 이메일과 비밀번호로 일치하는 계정이 존재하지 않아요.' });
+        onError: (error) => {
+          const errorMessage = typeof error.response?.data === 'string' ? error.response?.data : '';
+          setError('email', { type: 'server', message: ERROR_MESSAGE[errorMessage] || errorMessage });
         }
       }
     );

--- a/src/pages/Signin/index.tsx
+++ b/src/pages/Signin/index.tsx
@@ -17,7 +17,7 @@ const links = {
   signup: '/signup'
 };
 
-const formSchema = z.object({ email: z.string().email(), password: z.string() });
+const formSchema = z.object({ email: z.string().email('이메일 주소 형태로 입력해주세요.'), password: z.string() });
 
 type Inputs = z.infer<typeof formSchema>;
 
@@ -41,10 +41,8 @@ const SignIn = () => {
     mutate(
       { email: data.email, password: data.password },
       {
-        onError: (error) => {
-          const errorMessage = typeof error.response?.data === 'string' ? error.response?.data : '';
-          setError('email', { type: 'server', message: errorMessage });
-          setError('password', { type: 'server', message: errorMessage });
+        onError: () => {
+          setError('email', { type: 'server', message: '해당 이메일과 비밀번호로 일치하는 계정이 존재하지 않아요.' });
         }
       }
     );

--- a/src/pages/Signin/index.tsx
+++ b/src/pages/Signin/index.tsx
@@ -16,7 +16,7 @@ const ERROR_MESSAGE: {
   [key: string]: string;
 } = {
   'Your email and password combination does not match an account.':
-    '해당 이메일과 비밀번호로 일치하는 계정이 존재하지 않아요.'
+    '해당 이메일과 비밀번호로 일치하는 계정이 존재하지 않습니다.'
 };
 
 const links = {
@@ -24,7 +24,10 @@ const links = {
   signup: '/signup'
 };
 
-const formSchema = z.object({ email: z.string().email('이메일 주소 형태로만 입력할 수 있어요'), password: z.string() });
+const formSchema = z.object({
+  email: z.string().email('이메일 주소 형태로만 입력할 수 있습니다.'),
+  password: z.string()
+});
 
 type Inputs = z.infer<typeof formSchema>;
 

--- a/src/pages/Signin/index.tsx
+++ b/src/pages/Signin/index.tsx
@@ -50,7 +50,7 @@ const SignIn = () => {
       {
         onError: (error) => {
           const errorMessage = typeof error.response?.data === 'string' ? error.response?.data : '';
-          setError('email', { type: 'server', message: ERROR_MESSAGE[errorMessage] || errorMessage });
+          setError('password', { type: 'server', message: ERROR_MESSAGE[errorMessage] || errorMessage });
         }
       }
     );

--- a/src/pages/Signup/index.tsx
+++ b/src/pages/Signup/index.tsx
@@ -82,12 +82,12 @@ const SignUp = () => {
   return (
     <PageTemplate onSubmit={handleSubmit(onSubmit, onError)}>
       <Image maxW="32" src={musseuk} alt="머쓱이" />
-      <Heading textAlign="center">Sign up</Heading>
+      <Heading textAlign="center">회원가입</Heading>
       <InputField
         {...register('email')}
         id="email"
         type="email"
-        label="Email"
+        label="이메일"
         error={errors.email}
         placeholder="이메일을 입력해주세요"
       />
@@ -95,16 +95,16 @@ const SignUp = () => {
         {...register('username')}
         id="username"
         type="text"
-        label="Username"
+        label="이름"
         error={errors.username}
-        placeholder="실명을 입력해주세요"
+        placeholder="이름을 입력해주세요"
         maxLength={4}
       />
       <InputField
         {...register('password')}
         id="password"
         type={showPassword ? 'text' : 'password'}
-        label="Password"
+        label="비밀번호"
         placeholder="비밀번호를 입력해주세요"
         maxLength={30}
         icon={<Icon as={showPassword ? ViewOffIcon : ViewIcon} onClick={setShowPassword.toggle} />}
@@ -117,17 +117,17 @@ const SignUp = () => {
         {...register('confirmPassword')}
         id="confirm-password"
         type={showConfirmPassword ? 'text' : 'password'}
-        label="Confirm Password"
+        label="비밀번호 확인"
         placeholder="비밀번호를 재확인해주세요"
         maxLength={30}
         error={errors.confirmPassword}
         icon={<Icon as={showConfirmPassword ? ViewOffIcon : ViewIcon} onClick={setShowConfirmPassword.toggle} />}
       />
       <Button type="submit" mt="6" w="100%" colorScheme="primary">
-        Create account
+        회원가입
       </Button>
       <LinkTemplate>
-        <Text color="gray.400">Already have an account?</Text>
+        <Text color="gray.400">이미 가입하셨었나요?</Text>
         <Link to={links.signin}>
           <Text
             color="green.500"
@@ -140,7 +140,7 @@ const SignUp = () => {
             fontWeight="semibold"
             cursor="pointer"
             userSelect="none">
-            Sign in
+            로그인
           </Text>
         </Link>
       </LinkTemplate>

--- a/src/pages/Signup/index.tsx
+++ b/src/pages/Signup/index.tsx
@@ -12,6 +12,12 @@ import { isPasswordTooShort, isPasswordContainNumber } from './helpers/password'
 import InputField from './components/InputField';
 import { LinkTemplate } from './templates';
 
+const ERROR_MESSAGE: {
+  [key: string]: string;
+} = {
+  'The email address is already being used.': '이미 사용중인 이메일 주소에요'
+};
+
 const links = {
   main: '/',
   signin: '/signin'
@@ -19,20 +25,20 @@ const links = {
 
 const formSchema = z
   .object({
-    email: z.string().email(),
+    email: z.string().email('이메일 주소 형태로만 입력할 수 있어요'),
     username: z
       .string()
-      .min(2, 'Length must be greater than 2 characters')
-      .max(4, 'Length must be smaller than 4 characters')
-      .refine((value) => /^[가-힣]*$/.test(value), '한글만 입력해주세요'),
+      .min(2, '2글자에서 4글자로만 입력할 수 있어요')
+      .max(4, '2글자에서 4글자로만 입력할 수 있어요')
+      .refine((value) => /^[가-힣]*$/.test(value), '한글만 입력할 수 있어요'),
     password: z
       .string()
-      .min(8, 'Length must be greater than 8 characters')
-      .refine((value) => /\d/.test(value), 'Password must contain numbers'),
+      .min(8, '8글자 이상으로만 입력할 수 있어요')
+      .refine((value) => /\d/.test(value), '숫자를 반드시 포함해야 해요'),
     confirmPassword: z.string()
   })
   .refine((data) => data.password === data.confirmPassword, {
-    message: 'Passwords do not match',
+    message: '비밀번호가 일치하지 않아요',
     path: ['confirmPassword']
   });
 
@@ -63,7 +69,7 @@ const SignUp = () => {
       {
         onError: (error) => {
           const errorMessage = typeof error.response?.data === 'string' ? error.response?.data : '';
-          setError('email', { type: 'server', message: errorMessage });
+          setError('email', { type: 'server', message: ERROR_MESSAGE[errorMessage] || errorMessage });
         }
       }
     );
@@ -104,8 +110,8 @@ const SignUp = () => {
         icon={<Icon as={showPassword ? ViewOffIcon : ViewIcon} onClick={setShowPassword.toggle} />}
       />
       <Box w="100%" fontSize="sm">
-        {isPasswordTooShort(password) && <Text fontWeight="light">· Length must be greater than 8 characters</Text>}
-        {!isPasswordContainNumber(password) && <Text fontWeight="light">· Password must contain numbers</Text>}
+        {isPasswordTooShort(password) && <Text fontWeight="light">· 8글자 이상으로만 입력할 수 있어요</Text>}
+        {!isPasswordContainNumber(password) && <Text fontWeight="light">· 숫자를 반드시 포함해야 해요</Text>}
       </Box>
       <InputField
         {...register('confirmPassword')}

--- a/src/pages/Signup/index.tsx
+++ b/src/pages/Signup/index.tsx
@@ -15,7 +15,7 @@ import { LinkTemplate } from './templates';
 const ERROR_MESSAGE: {
   [key: string]: string;
 } = {
-  'The email address is already being used.': '이미 사용중인 이메일 주소에요'
+  'The email address is already being used.': '이미 사용중인 이메일 주소입니다.'
 };
 
 const links = {
@@ -25,20 +25,20 @@ const links = {
 
 const formSchema = z
   .object({
-    email: z.string().email('이메일 주소 형태로만 입력할 수 있어요'),
+    email: z.string().email('이메일 주소 형태로만 입력할 수 있습니다.'),
     username: z
       .string()
-      .min(2, '2글자에서 4글자로만 입력할 수 있어요')
-      .max(4, '2글자에서 4글자로만 입력할 수 있어요')
-      .refine((value) => /^[가-힣]*$/.test(value), '한글만 입력할 수 있어요'),
+      .min(2, '2글자에서 4글자로만 입력할 수 있습니다.')
+      .max(4, '2글자에서 4글자로만 입력할 수 있습니다.')
+      .refine((value) => /^[가-힣]*$/.test(value), '한글만 입력할 수 있습니다.'),
     password: z
       .string()
-      .min(8, '8글자 이상으로만 입력할 수 있어요')
-      .refine((value) => /\d/.test(value), '숫자를 반드시 포함해야 해요'),
+      .min(8, '8글자 이상으로만 입력할 수 있습니다.')
+      .refine((value) => /\d/.test(value), '숫자를 반드시 포함해야 합니다.'),
     confirmPassword: z.string()
   })
   .refine((data) => data.password === data.confirmPassword, {
-    message: '비밀번호가 일치하지 않아요',
+    message: '비밀번호가 일치하지 않습니다.',
     path: ['confirmPassword']
   });
 
@@ -110,8 +110,8 @@ const SignUp = () => {
         icon={<Icon as={showPassword ? ViewOffIcon : ViewIcon} onClick={setShowPassword.toggle} />}
       />
       <Box w="100%" fontSize="sm">
-        {isPasswordTooShort(password) && <Text fontWeight="light">· 8글자 이상으로만 입력할 수 있어요</Text>}
-        {!isPasswordContainNumber(password) && <Text fontWeight="light">· 숫자를 반드시 포함해야 해요</Text>}
+        {isPasswordTooShort(password) && <Text fontWeight="light">· 8글자 이상으로만 입력할 수 있습니다.</Text>}
+        {!isPasswordContainNumber(password) && <Text fontWeight="light">· 숫자를 반드시 포함해야 합니다.</Text>}
       </Box>
       <InputField
         {...register('confirmPassword')}


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, hotfix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈번호를 작성해주세요 ex) #11 -->
- close #139 

## ✅ 작업 사항 <!-- 가능한 구체적으로 작성해주세요 -->
- 각 페이지 한글화
- 비밀번호 변경 페이지에서 뒤로가기 클릭시 이전 페이지가 아니라 무조건 메인 페이지로 가지던 오류 수정
- NotFound 페이지에서 뒤로가기 클릭시 이전 페이지가 아니라 무조건 메인 페이지로 가지던 오류 수정

## 👩‍💻 공유 포인트 및 논의 사항 
![image](https://github.com/prgrms-fe-devcourse/FEDC4_MUSSEUK_LETTER_Donggeun/assets/50488780/4b514f2c-0f3e-4362-b320-dc2063a0a326)
![image](https://github.com/prgrms-fe-devcourse/FEDC4_MUSSEUK_LETTER_Donggeun/assets/50488780/de2b78c6-8cab-414c-906a-c9761840f43e)
![image](https://github.com/prgrms-fe-devcourse/FEDC4_MUSSEUK_LETTER_Donggeun/assets/50488780/4016c396-b4c0-426b-98e4-601b43aefc56)

### 논의 사항
![image](https://github.com/prgrms-fe-devcourse/FEDC4_MUSSEUK_LETTER_Donggeun/assets/50488780/da60ff65-5758-4e0c-ac67-164a0513bf8b)

헤더에 뒤로가기 기능은 없다보니, 비밀번호 변경 페이지에서 이전 페이지로 이동하는 기능은 필요하다고 생각해요.
`ex) 게시글 작성중이라면 /newpost 페이지로 이동하고, 특정 게시글을 보고 있었다면 /post/:postId` 페이지로 이동하고 등등..