### PR TITLE
hotfix: 슬랙 인증 페이지 버그 수정 및 기능 추가

### DIFF
--- a/src/apis/queries/useSlackTokenCheckQuery.ts
+++ b/src/apis/queries/useSlackTokenCheckQuery.ts
@@ -15,18 +15,17 @@ export const getTokenResult = async (slackToken: string) => {
   const { data } = await slackInstance.get<ResponseData>(`/slack/verification/user?token=${slackToken}`);
 
   storage('session').setItem(AUTH_TOKEN, data.token);
-
   queryClient.setQueryData(queryKey.auth, data.user);
-  setTimeout(() => queryClient.removeQueries(queryKey.slack.token(slackToken)), 0);
 
-  return data;
+  return data.user;
 };
 
 const useSlackTokenCheckQuery = (slackToken: string) => {
-  return useQuery<ResponseData>({
+  return useQuery<User>({
     queryKey: queryKey.slack.token(slackToken),
     queryFn: () => getTokenResult(slackToken),
-    suspense: true
+    suspense: true,
+    staleTime: Infinity
   });
 };
 

--- a/src/pages/Setting/SlackConfirmation/index.tsx
+++ b/src/pages/Setting/SlackConfirmation/index.tsx
@@ -13,7 +13,6 @@ const SlackConfirmation = () => {
   const navigate = useNavigate();
   const queryString = qs.parse(window.location.search, { ignoreQueryPrefix: true });
   const slackToken = String(queryString.token);
-
   const { data: slackResponseData } = useSlackTokenCheckQuery(slackToken);
 
   return (


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, hotfix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈번호를 작성해주세요 ex) #11 -->
- close #138

## ✅ 작업 사항 <!-- 가능한 구체적으로 작성해주세요 -->
- 슬랙 알림 인증 404 버그 수정했습니다( 상훈님 도움 감사합니다 😃)
- 이미 슬랙 인증을 완료한 사용자는 더이상 못하도록 막았습니다.
![image](https://github.com/prgrms-fe-devcourse/FEDC4_MUSSEUK_LETTER_Donggeun/assets/61399141/34957e49-af4b-4679-ba4d-3bb3c4b39742)

- 슬랙 인증하기 버튼을 눌렀을때 인증링크가 전송되었습니다 문구가 나타나게 했습니다
![image](https://github.com/prgrms-fe-devcourse/FEDC4_MUSSEUK_LETTER_Donggeun/assets/61399141/77cf709e-4322-4501-97b6-8125649f8de6)

- 비로그인시 로그인으로 리다이랙트 => useIsNotLoggedIn 사용

## 👩‍💻 공유 포인트 및 논의 사항 
