### PR TITLE
hotfix: localStorage로 수정

### DIFF
--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -12,7 +12,7 @@ export const slackInstance = axios.create({ baseURL: slackURL });
 
 authInstance.interceptors.request.use(
   (config) => {
-    const token = storage('session').getItem(AUTH_TOKEN, '');
+    const token = storage('local').getItem(AUTH_TOKEN, '');
 
     config.headers['Authorization'] = `Bearer ${token}`;
 
@@ -25,7 +25,7 @@ authInstance.interceptors.request.use(
 
 formDataInstance.interceptors.request.use(
   (config) => {
-    const token = storage('session').getItem(AUTH_TOKEN, '');
+    const token = storage('local').getItem(AUTH_TOKEN, '');
 
     config.headers['Authorization'] = `Bearer ${token}`;
     config.headers['Content-Type'] = 'multipart/form-data';
@@ -39,7 +39,7 @@ formDataInstance.interceptors.request.use(
 
 slackInstance.interceptors.request.use(
   (config) => {
-    const token = storage('session').getItem(AUTH_TOKEN, '');
+    const token = storage('local').getItem(AUTH_TOKEN, '');
 
     config.headers['Authorization'] = `Bearer ${token}`;
 

--- a/src/apis/mutations/useSignOutMutation.ts
+++ b/src/apis/mutations/useSignOutMutation.ts
@@ -16,7 +16,7 @@ const useSignOutMutation = () => {
   return useMutation({
     mutationFn: postSignOut,
     onMutate: () => {
-      storage('session').removeItem(AUTH_TOKEN);
+      storage('local').removeItem(AUTH_TOKEN);
       queryClient.removeQueries(queryKey.auth);
     }
   });

--- a/src/apis/mutations/useSigninMutation.ts
+++ b/src/apis/mutations/useSigninMutation.ts
@@ -29,7 +29,7 @@ const useSigninMutation = () => {
   return useMutation<ResponseData, AxiosError, RequestData>({
     mutationFn: postLogin,
     onSuccess: (data) => {
-      storage('session').setItem(AUTH_TOKEN, data.token);
+      storage('local').setItem(AUTH_TOKEN, data.token);
       queryClient.setQueryData(queryKey.auth, parseUser(data.user));
     }
   });

--- a/src/apis/mutations/useSignupMutation.ts
+++ b/src/apis/mutations/useSignupMutation.ts
@@ -48,7 +48,7 @@ const useSignupMutation = () => {
   return useMutation<ResponseData, AxiosError, CustomRequestData>({
     mutationFn: postSignup,
     onSuccess: (data) => {
-      storage('session').setItem(AUTH_TOKEN, data.token);
+      storage('local').setItem(AUTH_TOKEN, data.token);
       queryClient.setQueryData(queryKey.auth, parseUser(data.user));
     }
   });

--- a/src/apis/queries/useSlackTokenCheckQuery.ts
+++ b/src/apis/queries/useSlackTokenCheckQuery.ts
@@ -14,7 +14,7 @@ type ResponseData = {
 export const getTokenResult = async (slackToken: string) => {
   const { data } = await slackInstance.get<ResponseData>(`/slack/verification/user?token=${slackToken}`);
 
-  storage('session').setItem(AUTH_TOKEN, data.token);
+  storage('local').setItem(AUTH_TOKEN, data.token);
   queryClient.setQueryData(queryKey.auth, data.user);
 
   return data.user;

--- a/src/hooks/useIsNotLoggedIn.ts
+++ b/src/hooks/useIsNotLoggedIn.ts
@@ -9,7 +9,7 @@ const useIsNotLoggedIn = (options?: QueryOptions<User>) => {
 
   return {
     auth,
-    isNotLoggedIn: !auth && !storage('session').getItem(AUTH_TOKEN, null)
+    isNotLoggedIn: !auth && !storage('local').getItem(AUTH_TOKEN, null)
   };
 };
 

--- a/src/pages/Newpost/index.tsx
+++ b/src/pages/Newpost/index.tsx
@@ -104,7 +104,7 @@ const NewPost = () => {
     );
   };
 
-  if (!user && !storage('session').getItem(AUTH_TOKEN, null)) {
+  if (!user && !storage('local').getItem(AUTH_TOKEN, null)) {
     return <Navigate to={'/signin'} replace={true} />;
   }
 


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, hotfix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈번호를 작성해주세요 ex) #11 -->
- close #148 

## ✅ 작업 사항 <!-- 가능한 구체적으로 작성해주세요 -->
sessionStorage -> localStorage로 수정
메세지 링크를 접속했을 때, 이미 로그인한 사람이 또 새로운 탭에서 로그인해야하는 상황을 방지하기 위해 local Storage에 토큰을 저장하는 방식으로 의논해서 수정하게 되었습니다.

## 👩‍💻 공유 포인트 및 논의 사항 
