### PR TITLE
feat: 포스트 페이지 스타일 정리

### DIFF
--- a/src/components/TextCount/index.tsx
+++ b/src/components/TextCount/index.tsx
@@ -1,0 +1,18 @@
+import { Text, TextProps } from '@chakra-ui/react';
+
+type TextCountProps = {
+  count: number;
+  maxLength: number;
+} & TextProps;
+
+const TextCount = ({ count, maxLength, ...props }: TextCountProps) => {
+  const isExceeded = count > maxLength;
+
+  return (
+    <Text fontWeight={'light'} color={isExceeded ? 'orange.400' : 'inherit'} w={'90%'} textAlign={'right'} {...props}>
+      {`${count}/${maxLength}자`}
+    </Text>
+  );
+};
+
+export default TextCount;

--- a/src/pages/Post/components/AnnouncementText.tsx
+++ b/src/pages/Post/components/AnnouncementText.tsx
@@ -13,7 +13,7 @@ const AnnouncementText = ({ postId, ...props }: AnnouncementTextProps) => {
   const isAuthor = !!userData && !!postData && userData._id === postData.author._id;
 
   return (
-    <Heading size="xl" w={'70vw'} maxW="45rem" wordBreak={'keep-all'} {...props}>
+    <Heading fontSize={{ base: 24, md: 30 }} w={'70vw'} maxW="45rem" wordBreak={'keep-all'} {...props}>
       {isAuthor ? (
         <>
           {postData?.author.username} 님에게{' '}

--- a/src/pages/Post/components/Comment.tsx
+++ b/src/pages/Post/components/Comment.tsx
@@ -12,13 +12,15 @@ type CommentType = {
 
 const Comment = ({ top = 0, left = 0, decorationImageName, onClick }: CommentType) => {
   return (
-    <Box position="absolute" top={`${top}%`} left={`${left}%`} w="10%" h="10%">
+    <Box position="absolute" top={`${top}%`} left={`${left}%`} w="15%" h="15%">
       <Image
         src={DECORATION_IMAGE[decorationImageName]}
         alt={decorationImageName}
-        position="absolute"
+        position="relative"
         top="-50%"
         left="-50%"
+        boxSize={'100%'}
+        objectFit={'contain'}
         onClick={onClick}
       />
     </Box>

--- a/src/pages/Post/components/Comment.tsx
+++ b/src/pages/Post/components/Comment.tsx
@@ -1,4 +1,4 @@
-import { Box, Image } from '@chakra-ui/react';
+import { Box, Image, ImageProps } from '@chakra-ui/react';
 import React from 'react';
 import { DecorationType } from '@/types';
 import { DECORATION_IMAGE } from '../constants';
@@ -8,20 +8,24 @@ type CommentType = {
   left: number;
   decorationImageName: DecorationType;
   onClick: (e: React.MouseEvent) => void;
-};
+} & ImageProps;
 
-const Comment = ({ top = 0, left = 0, decorationImageName, onClick }: CommentType) => {
+const Comment = ({ top = 0, left = 0, decorationImageName, onClick, ...props }: CommentType) => {
   return (
-    <Box position="absolute" top={`${top}%`} left={`${left}%`} w="15%" h="15%">
+    <Box position="absolute" top={`${top}%`} left={`${left}%`} w="7.5%" h="7.5%">
       <Image
         src={DECORATION_IMAGE[decorationImageName]}
         alt={decorationImageName}
         position="relative"
-        top="-50%"
-        left="-50%"
-        boxSize={'100%'}
+        top="-100%"
+        left="-100%"
+        w={'200%'}
+        h={'200%'}
+        maxW={'none'}
         objectFit={'contain'}
         onClick={onClick}
+        zIndex={5}
+        {...props}
       />
     </Box>
   );

--- a/src/pages/Post/components/CommentBoard.tsx
+++ b/src/pages/Post/components/CommentBoard.tsx
@@ -77,7 +77,7 @@ const CommentBoard = ({ postId, onInfoOpen, onWriteOpen }: CommentBoardProps) =>
       border={isAuthor ? 'none' : '4px dashed'}
       borderColor={'green01'}
       boxSizing="border-box"
-      my={'3rem'}>
+      my={{ base: 'min(7.5%, 3rem)', '2xl': '0' }}>
       <Musseuk ref={musseukRef} musseukImageName={postData?.musseukImageName ?? 'musseuk_default'} />
       <CommentList>
         {postData &&

--- a/src/pages/Post/components/CommentBoard.tsx
+++ b/src/pages/Post/components/CommentBoard.tsx
@@ -34,6 +34,8 @@ const CommentBoard = ({ postId, onInfoOpen, onWriteOpen }: CommentBoardProps) =>
     const xRatio = ((clientX - x) / width) * 100;
     const yRatio = ((clientY - y) / height) * 100;
 
+    if (xRatio < 0 || xRatio > 100 || yRatio < 0 || yRatio > 100) return;
+
     dispatch({
       type: COMMENT_INFO_ACTION.POSITION,
       position: [xRatio, yRatio]
@@ -77,7 +79,9 @@ const CommentBoard = ({ postId, onInfoOpen, onWriteOpen }: CommentBoardProps) =>
       border={isAuthor ? 'none' : '4px dashed'}
       borderColor={'green01'}
       boxSizing="border-box"
-      my={{ base: 'min(7.5%, 3rem)', '2xl': '0' }}>
+      mt={{ base: 'min(7.5%, 3rem)', '2xl': '0' }}
+      mb={'min(7.5%, 3rem)'}
+      cursor={isAuthor ? 'default' : 'pointer'}>
       <Musseuk ref={musseukRef} musseukImageName={postData?.musseukImageName ?? 'musseuk_default'} />
       <CommentList>
         {postData &&
@@ -88,6 +92,7 @@ const CommentBoard = ({ postId, onInfoOpen, onWriteOpen }: CommentBoardProps) =>
               left={position[0]}
               decorationImageName={decorationImageName}
               onClick={handleCommentClick({ _id, author, content, nickname, decorationImageName })}
+              cursor={isAuthor || author._id === userData?._id ? 'pointer' : 'default'}
             />
           ))}
       </CommentList>

--- a/src/pages/Post/components/CommentBoard.tsx
+++ b/src/pages/Post/components/CommentBoard.tsx
@@ -76,7 +76,8 @@ const CommentBoard = ({ postId, onInfoOpen, onWriteOpen }: CommentBoardProps) =>
       onClick={handleMusseukClick}
       border={isAuthor ? 'none' : '4px dashed'}
       borderColor={'green01'}
-      boxSizing="border-box">
+      boxSizing="border-box"
+      my={'3rem'}>
       <Musseuk ref={musseukRef} musseukImageName={postData?.musseukImageName ?? 'musseuk_default'} />
       <CommentList>
         {postData &&

--- a/src/pages/Post/components/CommentInfoModal/index.tsx
+++ b/src/pages/Post/components/CommentInfoModal/index.tsx
@@ -81,7 +81,9 @@ const CommentInfoModal = ({ isOpen, onClose }: Pick<UseDisclosureReturn, 'isOpen
         <ModalBody p={'3rem'}>
           <VStack gap={6} alignItems={'end'}>
             <Box w={'100%'} minH={'14rem'} borderRadius={6} p={'1.5rem'} bg={'bg01'}>
-              <Text lineHeight={'150%'}>{content}</Text>
+              <Text lineHeight={'150%'} fontSize={18}>
+                {content}
+              </Text>
             </Box>
             <Flex w={'100%'} justifyContent={'space-between'}>
               {isMyComment && (

--- a/src/pages/Post/components/CommentWriteModal/Decoration.tsx
+++ b/src/pages/Post/components/CommentWriteModal/Decoration.tsx
@@ -26,7 +26,8 @@ const Decoration = ({ decoId, ...props }: DecorationProps) => {
       borderRadius="1rem"
       backgroundColor={state.isChecked ? 'yellow.50' : 'white'}
       mb="2rem"
-      mx="auto">
+      mx="auto"
+      cursor={'pointer'}>
       <input {...input} />
       <Box {...checkbox}>
         <Image src={DECORATION_IMAGE[decoId]} alt={decoId} h="5rem" userSelect="none" {...getLabelProps()} />

--- a/src/pages/Post/components/CommentWriteModal/index.tsx
+++ b/src/pages/Post/components/CommentWriteModal/index.tsx
@@ -81,14 +81,18 @@ const CommentWriteModal = ({ isOpen, onClose, postId }: CommentWriteModalProps) 
         <ModalBody>
           <form id="write" onSubmit={handleSubmit(onSubmit, onError)}>
             <VStack spacing="1rem">
-              <Heading textColor={isDecorationError ? 'orange.400' : 'black01'}>장식을 선택해주세요</Heading>
+              <Heading textColor={isDecorationError ? 'orange.400' : 'black01'} fontSize={{ base: 24, md: 30 }}>
+                장식을 선택해주세요
+              </Heading>
               <DecorationList
                 {...register('decorationImageName', { required: true })}
                 isError={isDecorationError}
                 setValue={setValue}
                 setIsError={setIsDecorationError}
               />
-              <Heading textColor={errors.content ? 'orange.400' : 'black01'}>메세지를 작성해주세요</Heading>
+              <Heading textColor={errors.content ? 'orange.400' : 'black01'} fontSize={{ base: 24, md: 30 }}>
+                메세지를 작성해주세요
+              </Heading>
               <Textarea
                 aria-invalid={isSubmitted ? !!errors.content : undefined}
                 {...register('content', {
@@ -101,8 +105,9 @@ const CommentWriteModal = ({ isOpen, onClose, postId }: CommentWriteModalProps) 
                 borderColor="gray03"
                 mb="1rem"
                 bgColor="white"
+                fontSize={18}
               />
-              <Heading>작성자에게 보여줄 닉네임</Heading>
+              <Heading fontSize={{ base: 24, md: 30 }}>수신자에게 보여줄 닉네임</Heading>
               <Input
                 {...register('nickname')}
                 placeholder="익명의 머쓱이"
@@ -111,6 +116,7 @@ const CommentWriteModal = ({ isOpen, onClose, postId }: CommentWriteModalProps) 
                 borderRadius="10px"
                 borderColor="gray03"
                 bgColor="white"
+                fontSize={16}
               />
             </VStack>
           </form>

--- a/src/pages/Post/components/CommentWriteModal/index.tsx
+++ b/src/pages/Post/components/CommentWriteModal/index.tsx
@@ -7,6 +7,7 @@ import {
   ModalCloseButton,
   ModalContent,
   ModalFooter,
+  Text,
   Textarea,
   UseDisclosureReturn,
   VStack,
@@ -18,6 +19,8 @@ import { useCommentInfoState } from '../../contexts/CommentInfoContext';
 import { SubmitErrorHandler, SubmitHandler, useForm } from 'react-hook-form';
 import useWriteCommentMutation from '@/apis/mutations/useWriteCommentMutation';
 import { useState } from 'react';
+import { MAX_LENGTH } from '../../constants';
+import TextCount from '@/components/TextCount';
 
 type CommentWriteModalProps = {
   postId: string;
@@ -34,8 +37,12 @@ const CommentWriteModal = ({ isOpen, onClose, postId }: CommentWriteModalProps) 
     handleSubmit,
     reset,
     setValue,
+    watch,
     formState: { isSubmitting, isSubmitted, errors }
   } = useForm<CommentField>();
+
+  const contentCount = watch('content')?.length ?? 0;
+  const nicknameCount = watch('nickname')?.length ?? 0;
 
   const onSubmit: SubmitHandler<CommentField> = (data) => {
     mutate(
@@ -70,6 +77,7 @@ const CommentWriteModal = ({ isOpen, onClose, postId }: CommentWriteModalProps) 
   const onError: SubmitErrorHandler<CommentField> = (errors) => setIsDecorationError(!!errors.decorationImageName);
 
   const handleClose = () => {
+    setIsDecorationError(false);
     reset();
     onClose();
   };
@@ -96,20 +104,28 @@ const CommentWriteModal = ({ isOpen, onClose, postId }: CommentWriteModalProps) 
               <Textarea
                 aria-invalid={isSubmitted ? !!errors.content : undefined}
                 {...register('content', {
-                  required: true
+                  required: true,
+                  maxLength: MAX_LENGTH.CONTENT
                 })}
                 w="90%"
                 h="10rem"
                 _placeholder={{ opacity: 1, color: 'gray03' }}
                 borderRadius="10px"
                 borderColor="gray03"
-                mb="1rem"
                 bgColor="white"
                 fontSize={18}
               />
-              <Heading fontSize={{ base: 24, md: 30 }}>수신자에게 보여줄 닉네임</Heading>
+              <TextCount count={contentCount} maxLength={MAX_LENGTH.CONTENT} />
+              <Heading
+                textColor={errors.nickname ? 'orange.400' : 'black01'}
+                fontSize={{ base: 24, md: 30 }}
+                mt={'1rem'}>
+                수신자에게 보여줄 닉네임
+              </Heading>
               <Input
-                {...register('nickname')}
+                {...register('nickname', {
+                  maxLength: MAX_LENGTH.NICKNAME
+                })}
                 placeholder="익명의 머쓱이"
                 w="90%"
                 _placeholder={{ opacity: 1, color: 'gray03' }}
@@ -118,6 +134,7 @@ const CommentWriteModal = ({ isOpen, onClose, postId }: CommentWriteModalProps) 
                 bgColor="white"
                 fontSize={16}
               />
+              <TextCount count={nicknameCount} maxLength={MAX_LENGTH.NICKNAME} />
             </VStack>
           </form>
         </ModalBody>

--- a/src/pages/Post/components/Introduction.tsx
+++ b/src/pages/Post/components/Introduction.tsx
@@ -10,8 +10,10 @@ const Introduction = ({ postId }: IntroductionProps) => {
 
   return (
     <>
-      <Heading mb="1rem">{data?.title}</Heading>
-      <Text maxW="40rem" fontSize="lg" wordBreak="keep-all">
+      <Heading maxW={'min(80vw, 40rem)'} fontSize={{ base: 24, md: 30 }} mb="1rem">
+        {data?.title}
+      </Heading>
+      <Text maxW={'min(80vw, 40rem)'} fontSize={{ base: 18, md: 24 }} wordBreak="keep-all">
         {data?.content}
       </Text>
     </>

--- a/src/pages/Post/components/Musseuk.tsx
+++ b/src/pages/Post/components/Musseuk.tsx
@@ -13,12 +13,12 @@ const Musseuk = forwardRef<HTMLImageElement, MusseukProps>(
       <Image
         src={MUSSEUK_IMAGE[musseukImageName]}
         alt="musseuk"
+        ref={ref}
         w="80vw"
         maxW="40rem"
         h="80vw"
         maxH="40rem"
         objectFit={'cover'}
-        ref={ref}
         {...props}
       />
     );

--- a/src/pages/Post/components/Musseuk.tsx
+++ b/src/pages/Post/components/Musseuk.tsx
@@ -13,10 +13,11 @@ const Musseuk = forwardRef<HTMLImageElement, MusseukProps>(
       <Image
         src={MUSSEUK_IMAGE[musseukImageName]}
         alt="musseuk"
-        w="90vw"
-        maxW="45rem"
-        h="90vw"
-        maxH="45rem"
+        w="80vw"
+        maxW="40rem"
+        h="80vw"
+        maxH="40rem"
+        objectFit={'cover'}
         ref={ref}
         {...props}
       />

--- a/src/pages/Post/components/Skeletons/CommentBoardSkeleton.tsx
+++ b/src/pages/Post/components/Skeletons/CommentBoardSkeleton.tsx
@@ -1,8 +1,8 @@
-import { Box, Skeleton, SkeletonCircle } from '@chakra-ui/react';
+import { Box, Skeleton } from '@chakra-ui/react';
 
 const CommentBoardSkeleton = () => {
   return (
-    <Box position={'relative'} w={'90vw'} maxW={'45rem'} h={'90vw'} maxH={'45rem'}>
+    <Box position={'relative'} w={'80vw'} maxW={'40rem'} h={'80vw'} maxH={'40rem'} my={'3rem'}>
       <Skeleton
         position={'absolute'}
         top={'20%'}

--- a/src/pages/Post/constants/index.ts
+++ b/src/pages/Post/constants/index.ts
@@ -38,3 +38,8 @@ export const DECORATION_IMAGE = {
   [DECORATION_IMAGE_NAME.SOJU1]: Soju1,
   [DECORATION_IMAGE_NAME.UH1]: Uh1
 } as const;
+
+export const MAX_LENGTH = {
+  CONTENT: 400,
+  NICKNAME: 10
+} as const;

--- a/src/pages/Post/index.tsx
+++ b/src/pages/Post/index.tsx
@@ -36,9 +36,9 @@ const Post = () => {
 
   const isAuthor = !!userData && !!postData && userData._id === postData.author._id;
 
-  if (isNotLoggedIn) return <Navigate to={links.signin} />;
+  if (isNotLoggedIn) return <Navigate to={links.signin} replace />;
 
-  if (isPostError) return <Navigate to={links.notFound} />;
+  if (isPostError) return <Navigate to={links.notFound} replace />;
 
   return (
     <CommentInfoProvider>

--- a/src/pages/Post/index.tsx
+++ b/src/pages/Post/index.tsx
@@ -16,6 +16,7 @@ import CommentBoardSkeleton from './components/Skeletons/CommentBoardSkeleton';
 import useIsNotLoggedIn from '@/hooks/useIsNotLoggedIn';
 import DeleteButton from './components/DeleteButton';
 import PostDeleteModal from './components/PostDeleteModal';
+import { HEADER_HEIGHT } from '@/components/header';
 
 const links = {
   notFound: '/notFound',
@@ -43,11 +44,12 @@ const Post = () => {
     <CommentInfoProvider>
       <VStack
         p="2rem 2rem 5rem 2rem"
+        minH={`calc(100% - ${HEADER_HEIGHT})`}
         backgroundColor="bg01"
         backgroundImage={BackgroundHome}
-        backgroundPosition="center"
-        backgroundSize="contain"
-        backgroundRepeat="no-repeat">
+        backgroundPosition="center 30%"
+        backgroundSize="min(80% + 384px, 1920px) auto"
+        backgroundRepeat="repeat-x">
         <Box w="100%" position={'relative'}>
           <Suspense fallback={<SkeletonText noOfLines={2} skeletonHeight={'2rem'} maxW={'45rem'} spacing={'1rem'} />}>
             <AnnouncementText postId={postId} mb="1rem" />


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, hotfix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈번호를 작성해주세요 ex) #11 -->
- close #155 

## ✅ 작업 사항 <!-- 가능한 구체적으로 작성해주세요 -->
- 장식을 머쓱이 크기의 10%에서 15%로 확대
- 머쓱이도 기존의 10% 정도 줄여서 스크롤 완화
- 화면 클 때 머쓱이 상단 마진 삭제해서 스크롤 완화
- 화면 작을 때 머쓱이 상단 마진 추가해서 장식과 텍스트가 겹치는 것 수정
- 텍스트 크기를 기준에 맞게 수정
- 배경 위치 상단 30%로 고정
- 배경을 화면이 작으면 확대해서 표시, 화면이 크면 repeat으로 처리
- 댓글 읽기 권한에 따라 장식 cursor 추가
- 댓글 작성 권한에 따라 머쓱이 cursor 추가
- 댓글 작성 구역 제한 강화
- 로그인 및 404 페이지 navigate 에 replace 속성 추가
- 댓글 작성 폼에 글자 수 제한 추가
- 입력 폼 글자 수 보여줄 `TextCount` 컴포넌트 추가

## 👩‍💻 공유 포인트 및 논의 사항 
