### PR TITLE
feat: 코멘트 작성 모달 인풋 글자수 제한 및 버튼 로딩

### DIFF
--- a/packages/web/src/pages/Post/components/CommentInfoModal/index.tsx
+++ b/packages/web/src/pages/Post/components/CommentInfoModal/index.tsx
@@ -27,7 +27,7 @@ const CommentInfoModal = ({ isOpen, onClose }: Pick<UseDisclosureReturn, 'isOpen
   const toast = useToast();
 
   const { data: userData } = useAuthCheckQuery();
-  const { mutate } = useDeleteCommentMutation(commentId);
+  const { mutate, isLoading } = useDeleteCommentMutation(commentId);
 
   const isMyComment = userData?._id === author._id;
 
@@ -88,7 +88,12 @@ const CommentInfoModal = ({ isOpen, onClose }: Pick<UseDisclosureReturn, 'isOpen
             <Flex w={'100%'} justifyContent={'space-between'}>
               {isMyComment && (
                 <Flex alignItems={'center'}>
-                  <DeleteButton onClick={handleDeleteClick} mr={3} colorScheme={isDeleteConfirm ? 'red' : 'primary'} />
+                  <DeleteButton
+                    onClick={handleDeleteClick}
+                    isLoading={isLoading}
+                    mr={3}
+                    colorScheme={isDeleteConfirm ? 'red' : 'primary'}
+                  />
                   {isDeleteConfirm && (
                     <DeleteConfirmText
                       display={{ base: 'none', md: 'inline' }}

--- a/packages/web/src/pages/Post/components/CommentInfoModal/index.tsx
+++ b/packages/web/src/pages/Post/components/CommentInfoModal/index.tsx
@@ -81,7 +81,7 @@ const CommentInfoModal = ({ isOpen, onClose }: Pick<UseDisclosureReturn, 'isOpen
         <ModalBody p={'3rem'}>
           <VStack gap={6} alignItems={'end'}>
             <Box w={'100%'} minH={'14rem'} borderRadius={6} p={'1.5rem'} bg={'bg01'}>
-              <Text lineHeight={'150%'} fontSize={18}>
+              <Text lineHeight={'150%'} fontSize={18} whiteSpace={'pre-wrap'}>
                 {content}
               </Text>
             </Box>

--- a/packages/web/src/pages/Post/components/CommentListModal/AccordionItems/index.tsx
+++ b/packages/web/src/pages/Post/components/CommentListModal/AccordionItems/index.tsx
@@ -12,7 +12,9 @@ const AccordionItems = ({ nickname, content }: Pick<CommentField, 'nickname' | '
           <AccordionIcon w={'24px'} h={'24px'} />
         </AccordionButton>
       </h2>
-      <AccordionPanel pb={4}>{content}</AccordionPanel>
+      <AccordionPanel pb={4} whiteSpace={'pre-wrap'}>
+        {content}
+      </AccordionPanel>
     </AccordionItem>
   );
 };

--- a/packages/web/src/pages/Post/components/CommentWriteModal/index.tsx
+++ b/packages/web/src/pages/Post/components/CommentWriteModal/index.tsx
@@ -7,7 +7,6 @@ import {
   ModalCloseButton,
   ModalContent,
   ModalFooter,
-  Text,
   Textarea,
   UseDisclosureReturn,
   VStack,
@@ -107,6 +106,7 @@ const CommentWriteModal = ({ isOpen, onClose, postId }: CommentWriteModalProps) 
                   required: true,
                   maxLength: MAX_LENGTH.CONTENT
                 })}
+                maxLength={MAX_LENGTH.CONTENT}
                 w="90%"
                 h="10rem"
                 _placeholder={{ opacity: 1, color: 'gray03' }}
@@ -126,6 +126,7 @@ const CommentWriteModal = ({ isOpen, onClose, postId }: CommentWriteModalProps) 
                 {...register('nickname', {
                   maxLength: MAX_LENGTH.NICKNAME
                 })}
+                maxLength={MAX_LENGTH.NICKNAME}
                 placeholder="익명의 머쓱이"
                 w="90%"
                 _placeholder={{ opacity: 1, color: 'gray03' }}

--- a/packages/web/src/pages/Post/components/CommentWriteModal/index.tsx
+++ b/packages/web/src/pages/Post/components/CommentWriteModal/index.tsx
@@ -30,14 +30,14 @@ const CommentWriteModal = ({ isOpen, onClose, postId }: CommentWriteModalProps) 
   const { position } = useCommentInfoState();
   const toast = useToast();
 
-  const { mutate } = useWriteCommentMutation(postId);
+  const { mutate, isLoading } = useWriteCommentMutation(postId);
   const {
     register,
     handleSubmit,
     reset,
     setValue,
     watch,
-    formState: { isSubmitting, isSubmitted, errors }
+    formState: { isSubmitted, errors }
   } = useForm<CommentField>();
 
   const contentCount = watch('content')?.length ?? 0;
@@ -143,7 +143,7 @@ const CommentWriteModal = ({ isOpen, onClose, postId }: CommentWriteModalProps) 
           <Button onClick={handleClose} mr="1.5rem">
             돌아가기
           </Button>
-          <Button type="submit" form="write" colorScheme="primary" disabled={isSubmitting}>
+          <Button type="submit" form="write" colorScheme="primary" isLoading={isLoading} loadingText={'작성 중..'}>
             작성하기
           </Button>
         </ModalFooter>

--- a/packages/web/src/pages/Post/components/Introduction.tsx
+++ b/packages/web/src/pages/Post/components/Introduction.tsx
@@ -13,7 +13,7 @@ const Introduction = ({ postId }: IntroductionProps) => {
       <Heading maxW={'min(80vw, 40rem)'} fontSize={{ base: 24, md: 30 }} mb="1rem">
         {data?.title}
       </Heading>
-      <Text maxW={'min(80vw, 40rem)'} fontSize={{ base: 18, md: 24 }} wordBreak="keep-all">
+      <Text maxW={'min(80vw, 40rem)'} fontSize={{ base: 18, md: 24 }} wordBreak="keep-all" whiteSpace={'pre-wrap'}>
         {data?.content}
       </Text>
     </>

--- a/packages/web/src/pages/Post/components/PostDeleteModal/index.tsx
+++ b/packages/web/src/pages/Post/components/PostDeleteModal/index.tsx
@@ -29,7 +29,7 @@ const PostDeleteModal = ({ isOpen, onClose, postId }: PostDeleteModalProps) => {
   const navigate = useNavigate();
 
   const { data } = usePostDetailQuery(postId);
-  const { mutate } = useDeletePostMutation(postId);
+  const { mutate, isLoading } = useDeletePostMutation(postId);
 
   const handleDeleteClick = () => {
     mutate(
@@ -95,7 +95,12 @@ const PostDeleteModal = ({ isOpen, onClose, postId }: PostDeleteModalProps) => {
                 <Button colorScheme={'gray'} size={'lg'} onClick={onClose}>
                   취소
                 </Button>
-                <Button colorScheme={'red'} size={'lg'} onClick={handleDeleteClick}>
+                <Button
+                  colorScheme={'red'}
+                  size={'lg'}
+                  onClick={handleDeleteClick}
+                  isLoading={isLoading}
+                  loadingText={'삭제 중..'}>
                   삭제
                 </Button>
               </HStack>


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, hotfix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈번호를 작성해주세요 ex) #11 -->
- close #172 

## ✅ 작업 사항 <!-- 가능한 구체적으로 작성해주세요 -->
- 코멘트 작성 모달에 있는 input에 maxLength를 추가로 줘서 더 길게 작성 못하도록 제한을 강화
- 코멘트 작성 모달의 제출 버튼, 코멘트 정보 모달의 삭제 버튼, 포스트 삭제 모달의 삭제 버튼에 로딩 추가해서 중복 제출 차단
- 머쓱이 소개글, 편지 내용 에서 new line `\n`이 무시되고 있던 오류 수정

## 👩‍💻 공유 포인트 및 논의 사항 
react hook form의 isSubmitting 이 제역할을 못하고 있었네요. 왜 일까요..