### PR TITLE
refactor: DB 스키마 변경 및 회원 email 필드 변경

### DIFF
--- a/packages/slack/jest.config.js
+++ b/packages/slack/jest.config.js
@@ -5,5 +5,6 @@ module.exports = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1'
   },
-  setupFiles: ['dotenv/config']
+  setupFiles: ['dotenv/config'],
+  testMatch: ['<rootDir>/src/**/*.test.ts']
 };

--- a/packages/slack/src/configs/database.ts
+++ b/packages/slack/src/configs/database.ts
@@ -1,8 +1,5 @@
 import { DataSource } from 'typeorm';
 import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
-import { User } from '@/models/User';
-import { Post } from '@/models/Post';
-import { Comment } from '@/models/Comment';
 
 const AppDataSource = new DataSource({
   type: 'mysql',
@@ -12,8 +9,7 @@ const AppDataSource = new DataSource({
   password: process.env.NODE_ENV === 'production' ? process.env.DEPLOY_DB_PASSWORD : process.env.LOCAL_DB_PASSWORD,
   database: process.env.DB_DATABASE,
   synchronize: true,
-  // logging: true,
-  entities: [User, Post, Comment],
+  entities: [__dirname + '/../models/*.{js,ts}'],
   subscribers: [],
   migrations: [],
   namingStrategy: new SnakeNamingStrategy()

--- a/packages/slack/src/domains/auth/auth.controller.ts
+++ b/packages/slack/src/domains/auth/auth.controller.ts
@@ -8,14 +8,14 @@ import authService from './auth.service';
 const router = express.Router();
 
 router.post('/signup', validationFilter(authValidator.signup), async (req, res) => {
-  const { name, password, username } = req.body as z.infer<typeof authValidator.signup.body>;
-  const { userId, accessToken } = await authService.signUp(username, password, name);
+  const { name, password, email } = req.body as z.infer<typeof authValidator.signup.body>;
+  const { userId, accessToken } = await authService.signUp(email, password, name);
   res.json({ userId, accessToken });
 });
 
 router.post('/signin', validationFilter(authValidator.signin), async (req, res) => {
-  const { username, password } = req.body as z.infer<typeof authValidator.signin.body>;
-  const { userId, accessToken } = await authService.signIn(username, password);
+  const { email, password } = req.body as z.infer<typeof authValidator.signin.body>;
+  const { userId, accessToken } = await authService.signIn(email, password);
   res.json({ userId, accessToken });
 });
 

--- a/packages/slack/src/domains/auth/auth.controller.ts
+++ b/packages/slack/src/domains/auth/auth.controller.ts
@@ -23,7 +23,7 @@ router.post('/signout', (req, res) => {
   res.json({ message: 'TODO: 로그아웃 구현 필요..' });
 });
 
-router.get('/check', authorizationFilter, async (req, res) => {
+router.get('/check', authorizationFilter(true), async (req, res) => {
   const signedUser = req.user;
   const accessToken = req.accessToken;
 
@@ -36,7 +36,7 @@ router.get('/check', authorizationFilter, async (req, res) => {
   res.json({ userId, accessToken });
 });
 
-router.put('/password', authorizationFilter, validationFilter(authValidator.password), async (req, res) => {
+router.put('/password', authorizationFilter(true), validationFilter(authValidator.password), async (req, res) => {
   const { password } = req.body as z.infer<typeof authValidator.password.body>;
   const signedUser = req.user;
 

--- a/packages/slack/src/domains/auth/auth.service.test.ts
+++ b/packages/slack/src/domains/auth/auth.service.test.ts
@@ -4,38 +4,38 @@ import { encryptText } from '@/utils/crypto';
 jest.mock('@/domains/users/users.repository');
 
 describe('회원가입', () => {
-  const mockUser = { id: 1, username: '아이디', password: '12341234', name: '이름' };
+  const mockUser = { userId: 1, email: 'email@haha.com', password: '12341234', name: '이름' };
 
   it('회원가입 성공', async () => {
-    UserRepository.findUserByUsername = jest.fn().mockResolvedValueOnce(mockUser);
+    UserRepository.findUserByEmail = jest.fn().mockResolvedValueOnce(mockUser);
 
-    const user = await authService.signUp(mockUser.username, mockUser.password, mockUser.name);
+    const user = await authService.signUp(mockUser.email, mockUser.password, mockUser.name);
 
-    expect(user.userId).toBe(mockUser.id);
+    expect(user.userId).toBe(mockUser.userId);
   });
 
   it('이미 존재하는 회원일 경우 예외가 발생한다', async () => {
     UserRepository.findOneBy = jest.fn().mockResolvedValueOnce(mockUser);
 
-    expect(authService.signUp(mockUser.username, mockUser.password, mockUser.name)).rejects.toThrow();
+    expect(authService.signUp(mockUser.email, mockUser.password, mockUser.name)).rejects.toThrow();
   });
 
   it('생성된 유저 정보를 찾을 수 없을 경우 예외가 발생한다', async () => {
-    UserRepository.findUserByUsername = jest.fn().mockResolvedValueOnce(null);
+    UserRepository.findUserByEmail = jest.fn().mockResolvedValueOnce(null);
 
-    expect(authService.signUp(mockUser.username, mockUser.password, mockUser.name)).rejects.toThrow();
+    expect(authService.signUp(mockUser.email, mockUser.password, mockUser.name)).rejects.toThrow();
   });
 });
 
 describe('로그인', () => {
-  const mockUser = { id: 1, password: encryptText('12341234', '시크릿'), salt: '시크릿' };
+  const mockUser = { userId: 1, password: encryptText('12341234', '시크릿'), salt: '시크릿' };
 
   it('로그인 성공', async () => {
     UserRepository.findOneBy = jest.fn().mockResolvedValueOnce(mockUser);
 
     const user = await authService.signIn('아이디', '12341234');
 
-    expect(user.userId).toBe(mockUser.id);
+    expect(user.userId).toBe(mockUser.userId);
   });
 
   it('존재하지 않는 회원일 경우 예외가 발생한다', async () => {
@@ -52,20 +52,20 @@ describe('로그인', () => {
 });
 
 describe('로그인 확인', () => {
-  const mockUser = { id: 1 };
+  const mockUser = { userId: 1 };
 
   it('로그인 확인 성공', async () => {
     UserRepository.findOneBy = jest.fn().mockResolvedValueOnce(mockUser);
 
-    const user = await authService.signCheck(mockUser.id);
+    const user = await authService.signCheck(mockUser.userId);
 
-    expect(user.userId).toBe(mockUser.id);
+    expect(user.userId).toBe(mockUser.userId);
   });
 
   it('DB에 유저 정보가 없을 경우 예외가 발생한다', async () => {
     UserRepository.findOneBy = jest.fn().mockResolvedValueOnce(null);
 
-    expect(authService.signCheck(mockUser.id)).rejects.toThrow();
+    expect(authService.signCheck(mockUser.userId)).rejects.toThrow();
   });
 });
 

--- a/packages/slack/src/domains/auth/auth.service.ts
+++ b/packages/slack/src/domains/auth/auth.service.ts
@@ -37,17 +37,13 @@ const authService = {
     const user = await UserRepository.findOneBy({ email });
 
     if (!user) {
-      throw new ValidationError({
-        email: '존재하지 않는 회원입니다.'
-      });
+      throw new ResponseError(400, '일치하는 회원이 없어요.');
     }
 
     const encryptedPassword = encryptText(password, user.salt);
 
     if (user.password !== encryptedPassword) {
-      throw new ValidationError({
-        password: '비밀번호가 일치하지 않습니다.'
-      });
+      throw new ResponseError(400, '일치하는 회원이 없어요.');
     }
 
     const accessToken = authService.generateAccessToken(user.userId, user.email, user.role);
@@ -62,7 +58,7 @@ const authService = {
     const user = await UserRepository.findOneBy({ userId });
 
     if (!user) {
-      throw new ResponseError(404, '사용자를 찾을 수 없어요.');
+      throw new ResponseError(500, '사용자를 찾을 수 없어요.');
     }
 
     return {
@@ -74,7 +70,7 @@ const authService = {
     const user = await UserRepository.findOneBy({ userId });
 
     if (!user) {
-      throw new ResponseError(404, '사용자를 찾을 수 없어요.');
+      throw new ResponseError(500, '사용자를 찾을 수 없어요.');
     }
 
     const salt = makeRandomString(64);

--- a/packages/slack/src/domains/auth/auth.service.ts
+++ b/packages/slack/src/domains/auth/auth.service.ts
@@ -4,8 +4,8 @@ import { ResponseError, ValidationError } from '@/utils/ResponseError';
 import { makeRandomString, encryptText } from '@/utils/crypto';
 
 const authService = {
-  async signUp(username: string, password: string, name: string) {
-    if (await UserRepository.findOneBy({ username })) {
+  async signUp(email: string, password: string, name: string) {
+    if (await UserRepository.findOneBy({ email })) {
       throw new ResponseError(409, '이미 존재하는 회원입니다.');
     }
 
@@ -14,31 +14,31 @@ const authService = {
 
     await UserRepository.insert({
       name,
-      username,
+      email,
       password: encryptedPassword,
       salt: salt
     });
 
-    const insertedUser = await UserRepository.findUserByUsername({ username });
+    const insertedUser = await UserRepository.findUserByEmail({ email });
 
     if (!insertedUser) {
       throw new ResponseError(500, '회원가입에 실패했습니다.');
     }
 
-    const accessToken = authService.generateAccessToken(insertedUser.id, insertedUser.username, insertedUser.role);
+    const accessToken = authService.generateAccessToken(insertedUser.userId, insertedUser.email, insertedUser.role);
 
     return {
-      userId: insertedUser.id,
+      userId: insertedUser.userId,
       accessToken
     };
   },
 
-  async signIn(username: string, password: string) {
-    const user = await UserRepository.findOneBy({ username });
+  async signIn(email: string, password: string) {
+    const user = await UserRepository.findOneBy({ email });
 
     if (!user) {
       throw new ValidationError({
-        username: '존재하지 않는 회원입니다.'
+        email: '존재하지 않는 회원입니다.'
       });
     }
 
@@ -50,28 +50,28 @@ const authService = {
       });
     }
 
-    const accessToken = authService.generateAccessToken(user.id, user.username, user.role);
+    const accessToken = authService.generateAccessToken(user.userId, user.email, user.role);
 
     return {
-      userId: user.id,
+      userId: user.userId,
       accessToken
     };
   },
 
   async signCheck(userId: number) {
-    const user = await UserRepository.findOneBy({ id: userId });
+    const user = await UserRepository.findOneBy({ userId });
 
     if (!user) {
       throw new ResponseError(404, '사용자를 찾을 수 없어요.');
     }
 
     return {
-      userId: user.id
+      userId: user.userId
     };
   },
 
   async changePassword(userId: number, password: string) {
-    const user = await UserRepository.findOneBy({ id: userId });
+    const user = await UserRepository.findOneBy({ userId });
 
     if (!user) {
       throw new ResponseError(404, '사용자를 찾을 수 없어요.');
@@ -80,14 +80,14 @@ const authService = {
     const salt = makeRandomString(64);
     const encryptedPassword = encryptText(password, salt);
 
-    await UserRepository.update(user.id, {
+    await UserRepository.update(user.userId, {
       password: encryptedPassword,
       salt: salt
     });
   },
 
-  generateAccessToken(id: number, username: string, role: string) {
-    const accessToken = jwt.sign({ id, username, role }, process.env.JWT_SECRET_KEY, {
+  generateAccessToken(id: number, email: string, role: string) {
+    const accessToken = jwt.sign({ id, email, role }, process.env.JWT_SECRET_KEY, {
       expiresIn: process.env.JWT_EXPIRES_IN
     });
 

--- a/packages/slack/src/domains/auth/auth.validator.ts
+++ b/packages/slack/src/domains/auth/auth.validator.ts
@@ -3,12 +3,13 @@ import { z } from 'zod';
 const authValidator = {
   signup: {
     body: z.object({
-      username: z
+      email: z
         .string({
-          required_error: '아이디를 입력해주세요.'
+          required_error: '이메일을 입력해주세요.'
         })
-        .min(1, '아이디를 입력해주세요.')
-        .max(20, '아이디는 최대 20글자까지만 입력할 수 있습니다.'),
+        .email({
+          message: '이메일 형식이 아닙니다.'
+        }),
       password: z
         .string({
           required_error: '비밀번호를 입력해주세요.'
@@ -25,9 +26,13 @@ const authValidator = {
   },
   signin: {
     body: z.object({
-      username: z.string({
-        required_error: '아이디를 입력해주세요.'
-      }),
+      email: z
+        .string({
+          required_error: '이메일을 입력해주세요.'
+        })
+        .email({
+          message: '이메일 형식이 아닙니다.'
+        }),
       password: z.string({
         required_error: '비밀번호를 입력해주세요.'
       })

--- a/packages/slack/src/domains/users/users.repository.ts
+++ b/packages/slack/src/domains/users/users.repository.ts
@@ -2,13 +2,13 @@ import AppDataSource from '@/configs/database';
 import { User } from '@/models/User';
 
 const UserRepository = AppDataSource.getRepository(User).extend({
-  async findUserByUsername({ username }: { username: string }) {
+  async findUserByEmail({ email }: { email: string }) {
     const user: Pick<
       User,
-      'id' | 'username' | 'role' | 'name' | 'introduce' | 'imageName' | 'slackId' | 'slackWorkspace'
+      'userId' | 'email' | 'role' | 'name' | 'introduce' | 'imageUrl' | 'slackId' | 'slackWorkspace'
     > | null = await this.findOne({
-      select: ['id', 'username', 'role', 'name', 'introduce', 'imageName', 'slackId', 'slackWorkspace'],
-      where: { username }
+      select: ['userId', 'email', 'role', 'name', 'introduce', 'imageUrl', 'slackId', 'slackWorkspace'],
+      where: { email }
     });
 
     return user;

--- a/packages/slack/src/models/Comment.ts
+++ b/packages/slack/src/models/Comment.ts
@@ -1,13 +1,26 @@
-import { Entity, Column, PrimaryGeneratedColumn, ManyToOne } from 'typeorm';
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn } from 'typeorm';
 import { Post } from './Post';
+import { User } from './User';
 
 @Entity()
 export class Comment {
   @PrimaryGeneratedColumn()
-  id!: number;
+  commentId!: number;
 
-  @Column({ length: 50 })
-  author!: string;
+  @ManyToOne(() => Post, (post) => post.comments, {
+    cascade: true
+  })
+  @JoinColumn({ name: 'post_id' })
+  post!: Post;
+
+  @ManyToOne(() => User, (user) => user.comments, {
+    cascade: true
+  })
+  @JoinColumn({ name: 'author_id' })
+  author!: User;
+
+  @Column({ length: 50, default: '익명의 머쓱이' })
+  nickname!: string;
 
   @Column({ length: 500 })
   content!: string;
@@ -26,9 +39,4 @@ export class Comment {
 
   @Column({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
   updatedAt!: Date;
-
-  @ManyToOne(() => Post, (post) => post.comments, {
-    cascade: true
-  })
-  post!: Post;
 }

--- a/packages/slack/src/models/Post.ts
+++ b/packages/slack/src/models/Post.ts
@@ -1,11 +1,20 @@
-import { Entity, Column, PrimaryGeneratedColumn, OneToMany, ManyToOne } from 'typeorm';
+import { Entity, Column, PrimaryGeneratedColumn, OneToMany, ManyToOne, JoinColumn } from 'typeorm';
 import { User } from './User';
 import { Comment } from './Comment';
 
 @Entity()
 export class Post {
   @PrimaryGeneratedColumn()
-  id!: number;
+  postId!: number;
+
+  @ManyToOne(() => User, (user) => user.posts, {
+    cascade: true
+  })
+  @JoinColumn({ name: 'author_id' })
+  author!: User;
+
+  @OneToMany(() => Comment, (comment) => comment.commentId)
+  comments!: Comment[];
 
   @Column({ length: 50 })
   title!: string;
@@ -21,12 +30,4 @@ export class Post {
 
   @Column({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
   updatedAt!: Date;
-
-  @ManyToOne(() => User, (user) => user.posts, {
-    cascade: true
-  })
-  author!: User;
-
-  @OneToMany(() => Comment, (comment) => comment.id)
-  comments!: Comment[];
 }

--- a/packages/slack/src/models/User.ts
+++ b/packages/slack/src/models/User.ts
@@ -1,13 +1,20 @@
 import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
 import { Post } from './Post';
+import { Comment } from './Comment';
 
 @Entity()
 export class User {
   @PrimaryGeneratedColumn()
-  id!: number;
+  userId!: number;
 
-  @Column({ length: 50, unique: true })
-  username!: string;
+  @OneToMany(() => Post, (post) => post.author)
+  posts!: Post[];
+
+  @OneToMany(() => Comment, (comment) => comment.author)
+  comments!: Post[];
+
+  @Column({ unique: true })
+  email!: string;
 
   @Column()
   password!: string;
@@ -24,13 +31,13 @@ export class User {
   @Column({ nullable: true })
   introduce!: string;
 
-  @Column({ length: 50, nullable: true })
-  imageName!: string;
+  @Column({ nullable: true })
+  imageUrl!: string;
 
   @Column({ length: 50, nullable: true })
   slackId!: string;
 
-  @Column({ length: 20, nullable: true })
+  @Column({ length: 50, nullable: true })
   slackWorkspace!: string;
 
   @Column({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
@@ -38,7 +45,4 @@ export class User {
 
   @Column({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
   updatedAt!: Date;
-
-  @OneToMany(() => Post, (post) => post.author)
-  posts!: Post[];
 }

--- a/packages/slack/tsconfig.json
+++ b/packages/slack/tsconfig.json
@@ -33,5 +33,5 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src", "./src/**/*.ts"],
-  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, hotfix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈번호를 작성해주세요 ex) #11 -->
- close #233 

## ✅ 작업 사항 <!-- 가능한 구체적으로 작성해주세요 -->
### 작업 내용
- DB 스키마 변경
- Auth 관련 도메인에서 회원 `username` 을 모두 `email` 로 변경
- 테스트 코드에도 수정 사항 반영
- `test` 스크립트 실행 시, `src` 디렉토리 하위의 테스트 코드만 실행하도록 변경

### 이슈 트래킹
#### import 인식 불가능
![image](https://github.com/prgrms-fe-devcourse/FEDC4_MUSSEUK_LETTER_Donggeun/assets/50488780/6f2ccf5d-c5ba-48e4-be84-27dc13d68732)

`tsconfig.json` 의 `exclude` 에 모든 테스트 코드를 빌드 하지 않도록 넣었더니, IDE에서 테스트 코드에 들어가면 타입 스크립트 import를 인식하지 못하는 문제가 있었어요. (path-alias 불가능)

#### 테스트 코드에서 스키마 불러오기 실패

![image](https://github.com/prgrms-fe-devcourse/FEDC4_MUSSEUK_LETTER_Donggeun/assets/50488780/f3ea6daa-fd5e-4665-8531-b88d64985dd6)

그래서 테스트 코드를 빌드하고 수행했는데, **EntityMetadataNotFoundError: No metadata for "User" was found.** 라면서 스키마를 가져오지 못하는 문제가 있었어요.

#### 해결
CI 단계에서 빌드된 테스트 코드는 사용하지 않고, 그냥 `src` 디렉토리에 있는 테스트 코드만 실행하도록 `jest.config.js` 에 `testMatch` 옵션을 부여했어요.

사실.. 빌드된 테스트 코드를 실행하는 게 맞는 방법인 것 같긴 한데 문제 해결 방법을 아직 모르겠어서 우선 진행했어요..

## 👩‍💻 공유 포인트 및 논의 사항 
### ERD
![image](https://github.com/prgrms-fe-devcourse/FEDC4_MUSSEUK_LETTER_Donggeun/assets/50488780/ad3dbfbd-f1d6-47ef-a869-91e75fb43d92)

