### PR TITLE
refactor: authorizationFilter에 throwsOnError 파라미터 추가

### DIFF
--- a/packages/slack/src/domains/auth/auth.controller.ts
+++ b/packages/slack/src/domains/auth/auth.controller.ts
@@ -23,7 +23,7 @@ router.post('/signout', (req, res) => {
   res.json({ message: 'TODO: 로그아웃 구현 필요..' });
 });
 
-router.get('/check', authorizationFilter, async (req, res) => {
+router.get('/check', authorizationFilter(true), async (req, res) => {
   const signedUser = req.user;
   const accessToken = req.accessToken;
 
@@ -36,7 +36,7 @@ router.get('/check', authorizationFilter, async (req, res) => {
   res.json({ userId, accessToken });
 });
 
-router.put('/password', authorizationFilter, validationFilter(authValidator.password), async (req, res) => {
+router.put('/password', authorizationFilter(true), validationFilter(authValidator.password), async (req, res) => {
   const { password } = req.body as z.infer<typeof authValidator.password.body>;
   const signedUser = req.user;
 

--- a/packages/slack/src/domains/auth/auth.service.ts
+++ b/packages/slack/src/domains/auth/auth.service.ts
@@ -37,17 +37,13 @@ const authService = {
     const user = await UserRepository.findOneBy({ email });
 
     if (!user) {
-      throw new ValidationError({
-        email: '존재하지 않는 회원입니다.'
-      });
+      throw new ResponseError(400, '일치하는 회원이 없어요.');
     }
 
     const encryptedPassword = encryptText(password, user.salt);
 
     if (user.password !== encryptedPassword) {
-      throw new ValidationError({
-        password: '비밀번호가 일치하지 않습니다.'
-      });
+      throw new ResponseError(400, '일치하는 회원이 없어요.');
     }
 
     const accessToken = authService.generateAccessToken(user.userId, user.email, user.role);
@@ -62,7 +58,7 @@ const authService = {
     const user = await UserRepository.findOneBy({ userId });
 
     if (!user) {
-      throw new ResponseError(404, '사용자를 찾을 수 없어요.');
+      throw new ResponseError(500, '사용자를 찾을 수 없어요.');
     }
 
     return {
@@ -74,7 +70,7 @@ const authService = {
     const user = await UserRepository.findOneBy({ userId });
 
     if (!user) {
-      throw new ResponseError(404, '사용자를 찾을 수 없어요.');
+      throw new ResponseError(500, '사용자를 찾을 수 없어요.');
     }
 
     const salt = makeRandomString(64);


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, hotfix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈번호를 작성해주세요 ex) #11 -->
- close #235 

## ✅ 작업 사항 <!-- 가능한 구체적으로 작성해주세요 -->
- 로그인 API 실패 응답시 `validation` 필드 보내주지 않도록 수정
- 로그인 확인, 비밀번호 변경 API에서 응답을 404가 아닌 500으로 보내도록 수정
- `authoriationFilter` 미들웨어에 throwsOnError 플래그 변수 추가
  - (댓글 작성 API 처럼 회원과 비회원이 모두 사용할 수 있는 경우를 대비했어요.)
  - 관련된 테스트 코드 수정

## 👩‍💻 공유 포인트 및 논의 사항 
### authorizationFilter
throwsOnError가 `true`이면 액세스 토큰 검증 실패시 후행하는 미들웨어가 실행되지 않아요.

```ts
router.get('/check', authorizationFilter(true), async (req, res) => {
  const signedUser = req.user;
  const accessToken = req.accessToken;
});
```

throwsOnError가 `false`이면 액세스 토큰 검증 실패시에도 후행하는 미들웨어가 실행되어요.
단, `req.user`, `req.accessToken` 값은 비어 있어요.

```ts
router.get('/check', authorizationFilter(false), async (req, res) => {
  const signedUser = req.user; // 로그인 실패시 undefined
  const accessToken = req.accessToken; // 로그인 실패시 undefined
});
```

필터에 이런 분기 처리가 들어가는 게 단일 책임의 원칙에 위배되는 걸지도 모르겠지만..
분리하기에도 반복적인 로직이 많아지는 것 같아서 하나의 필터에서 분기 처리 하도록 구현했어요.


`main` <- `refactor/233-db-schema` <- `feature/235-filter` 순서로 머지할 예정입니다!